### PR TITLE
feat: add JoinQuant research workspace and remote execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ __pycache__/
 *.py[cod]
 *.egg-info/
 .pytest_cache/
+build/
 uv.lock

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,6 +1,6 @@
 # jqcli 设计文档
 
-聚宽（JoinQuant）策略与回测管理命令行工具。
+聚宽（JoinQuant）策略、回测与研究工作区管理命令行工具。
 
 MVP 目标：在 Windows 和常见命令行环境中稳定运行，并能被 agent/skill 以非交互方式调用。人类友好的表格、确认提示、编辑器集成可以提供，但不能影响自动化主路径。
 
@@ -23,7 +23,9 @@ jqcli
 ├── auth        认证管理
 ├── strategy    策略管理
 ├── backtest    回测管理
-└── community   社区文章
+├── research    研究文件管理
+├── community   社区文章
+└── web         本地文章管理界面
 ```
 
 ### 技术选型
@@ -32,6 +34,7 @@ jqcli
 |------|------|------|
 | CLI 框架 | `click` | 子命令分组、参数解析、帮助生成 |
 | HTTP 客户端 | `httpx` | 同步请求，统一超时 |
+| WebSocket 客户端 | `websockets>=15,<16` | Jupyter channels 同步通信；禁用代理并显式限定同源凭据 |
 | 配置存储 | JSON 文件 | 跨平台配置路径 |
 | 凭据来源 | 环境变量优先，配置文件兜底 | 避免 keyring 在 agent/CI 中卡住 |
 | 输出渲染 | `rich` 可选 | 只用于 table 输出；JSON 输出不用 rich |
@@ -154,6 +157,7 @@ JSON 错误格式：
 - 登录、token/cookie 校验方式。
 - 策略列表、新建、读取、更新、删除接口。
 - 回测提交、列表、详情接口。
+- 研究平台 SSO、Contents API 和动态用户 base path。
 - 认证失败、资源不存在、限流、服务端错误的响应格式。
 
 MVP 不强制抽象完整领域模型，只要求内部字段稳定映射到 JSON 输出。策略和回测至少包含以下字段：
@@ -184,6 +188,62 @@ MVP 不强制抽象完整领域模型，只要求内部字段稳定映射到 JSO
   "metrics": {}
 }
 ```
+
+### Research
+
+研究平台不是 `/algorithm` 接口：主站 Cookie 先读取 `/default/research/redirect`，将页面中的短期字段 POST 到同源 `/hub/login`，跟随 JupyterHub/OAuth 重定向后从 Notebook 页面 `data-base-url` 获取动态 `/user/<user>/` 前缀。整个过程必须使用同一可更新 cookie jar，且不得输出用户名、短期 token 或 Hub cookie。
+
+当前真实环境为 Jupyter Notebook 5.4.1，读取接口为：
+
+```text
+GET <base>/api/contents/<path>?content=0|1
+```
+
+CLI 对资源模型做稳定的字段裁剪：
+
+```json
+{
+  "name": "factor.ipynb",
+  "path": "research/factor.ipynb",
+  "type": "notebook",
+  "writable": true,
+  "created": "2026-08-14T08:00:00Z",
+  "last_modified": "2026-08-14T09:00:00Z",
+  "mimetype": null,
+  "format": null,
+  "size": null
+}
+```
+
+目录的 `content` 是一层子项数组；文件正文只有显式请求时才返回。远端路径统一转换为 `/`，逐段 URL 编码并拒绝 `.`、`..`、空组件和 NUL。
+
+Jupyter 写接口还依赖 `_xsrf` 与 `X-XSRFToken`。上传、建目录、移动和删除以实例自报的 Notebook 5.4.1 同版本官方实现为契约，并只使用 mock 测试验证；真实账号验收保持只读。
+
+研究实例还开放同版本 Jupyter KernelSpec、Kernel 与 Session API：
+
+```text
+GET    <base>/api/kernelspecs
+GET    <base>/api/kernels
+POST   <base>/api/kernels
+DELETE <base>/api/kernels/<kernel_id>
+GET    <base>/api/sessions
+POST   <base>/api/sessions
+DELETE <base>/api/sessions/<session_id>
+WS     <base>/api/kernels/<kernel_id>/channels?session_id=<client_session_id>
+```
+
+真实账号只读探测确认 `kernelspecs` 返回 `200` 和 3 个规格，`kernels`、`sessions` 均返回 `200` 和空列表；对随机且确定不存在的标准 UUID 进行普通 channels GET 返回 `404`。路由与 WebSocket 消息格式再以 Notebook 5.4.1 官方 `kernel.js`、`session.js` 及服务端 handler 交叉确认。探测没有读取研究文件正文，也没有启动、连接或停止现有内核。
+
+远端执行遵守以下资源与安全模型：
+
+1. `research exec` 每次创建使用高熵合成路径的临时 session 与新内核；`research run` 每次创建关联目标 Notebook 的高熵临时 session 与新内核。合成路径只用于追踪和清理，不调用 Contents 保存接口；两者绝不选择或复用 `research kernels`、`research sessions` 中的现有对象。
+2. WebSocket 只连接刚创建的内核，沿用动态 base path、已更新的 Cookie 与同源 `Origin`；任何自动跨源重定向都视为协议错误。
+3. 代码通过 Jupyter `execute_request` 发送；客户端收集 `stream`、`display_data`、`execute_result`、`error`、`execute_reply` 与状态事件，并以匹配的父消息 id 判定归属。
+4. 成功、执行错误、超时、协议失败或用户中断均进入 `finally` 清理路径；优先删除临时 session，并确保临时 kernel 被停止。清理不得作用于调用开始前已存在的对象。
+5. 执行任意代码可能产生文件、网络或计算副作用，因此即使在交互式 table 模式也必须显式传 `--yes`，不以提示确认替代。
+6. `research run` 只读取用户明确指定的 Notebook；默认且当前始终不调用 Contents 保存接口，执行输出不会写回远端 Notebook。
+
+全局 `--timeout` 仍约束单次 HTTP 操作；执行等待由命令级 `--execution-timeout` 单独约束。非流式模式在结束后输出结构化结果；`--stream` 仅支持 JSON 格式，按到达顺序逐行输出 JSONL 事件，末行固定为 `{"event":"done","result":{...}}`，便于实时消费标准输出、展示结果与错误。
 
 时间使用 ISO 8601；CLI 日期输入使用 `YYYY-MM-DD`；百分比在 JSON 中使用小数值，例如 `0.1832`。
 
@@ -373,6 +433,106 @@ jqcli community clone-strategy <post_id>
 - JSON 检查输出会隐藏 `secret`，只返回 `secret_present` 和 `random_present`。
 - 回复中附带回测时可传 `--reply-id`。
 
+### `jqcli research ls`
+
+列出研究根目录或指定子目录的一层内容。
+
+```
+jqcli research ls [path]
+```
+
+- 默认路径为空，等价于根目录。
+- JSON 返回 `path`、`items` 和 `total`。
+- 不递归，不读取文件正文。
+
+### `jqcli research show`
+
+```
+jqcli research show <path> [--content]
+```
+
+- 默认只读取元数据。
+- `--content` 对 Notebook 返回 JSON 模型，对文本文件返回字符串，对二进制文件保留 base64。
+
+### `jqcli research download`
+
+```
+jqcli research download <path> [--output <local-path>] [--force]
+```
+
+- 只读取远端并写入本地，不修改研究平台资产。
+- 默认以远端 basename 作为本地文件名。
+- 目标已存在时失败；只有 `--force` 才覆盖。
+- 文本使用 UTF-8，Notebook 写为 JSON，base64 内容先解码；目录不可下载。
+
+### `jqcli research upload`
+
+```
+jqcli research upload <local-path> [remote-path] [--force] [--yes]
+```
+
+- `.ipynb` 使用 `type=notebook, format=json`；UTF-8 文件使用 `type=file, format=text`；二进制使用 `format=base64`。
+- 远端目标存在时默认失败，只有 `--force` 才覆盖。
+- 非交互模式或 JSON 模式必须显式传 `--yes`；交互式 table 模式会确认。
+- 当前单次上传上限为 25 MiB，不实现 Jupyter 前端的大文件分块协议。
+
+### `jqcli research mkdir / mv / rm`
+
+```
+jqcli research mkdir <path> [--yes]
+jqcli research mv <source> <destination> [--yes]
+jqcli research rm <path> [--yes]
+```
+
+- 三类命令都修改远端研究资产，非交互模式或 JSON 模式必须传 `--yes`，交互式 table 模式会确认。
+- 根目录不能创建、移动或删除。
+- 删除调用 Contents `DELETE`；不假设聚宽实例一定提供可恢复回收站。
+
+### `jqcli research kernelspecs / kernels / sessions`
+
+```
+jqcli research kernelspecs
+jqcli research kernels
+jqcli research sessions
+```
+
+- 三个命令均为只读发现接口，不创建、连接、停止或复用远端对象。
+- JSON 输出裁剪为稳定模型；不得把 Cookie、短期 SSO token 或未请求的 Notebook 内容带入输出。
+- 自动化冒烟摘要只记录数量和布尔值，不输出 kernel/session id、Notebook 路径或内核规格名称。
+
+### `jqcli research exec`
+
+```
+jqcli research exec (--file <local.py> | --code-stdin)
+                    [--kernel <name>]
+                    [--execution-timeout <seconds>]
+                    [--stream]
+                    --yes
+```
+
+- `--file` 与 `--code-stdin` 互斥且必须选择一个；代码按 UTF-8 读取。
+- `--kernel` 省略时使用服务端默认内核。
+- 每次调用创建并只连接 jqcli 自己的临时 session 与新内核，合成 session 不保存研究文件，结束时无条件清理。
+- `--stream` 仅支持 `--format json`，输出按到达顺序排列的 JSONL 执行事件，并以 `done` 事件结束；不传时在执行完成后输出结构化结果。
+- `--yes` 永远必需，因为代码本身可能修改研究资产或其他远端状态。
+
+### `jqcli research run`
+
+```
+jqcli research run <remote.ipynb>
+                   [--cell <zero-based-index>]...
+                   [--kernel <name>]
+                   [--execution-timeout <seconds>]
+                   [--stream]
+                   --yes
+```
+
+- 默认按 Notebook 原始顺序执行全部 code cell；重复传 `--cell` 时只执行指定的零基索引单元。
+- 未显式传 `--kernel` 时优先使用 Notebook `metadata.kernelspec.name`，缺失时回退平台默认内核。
+- 只读取明确指定的 Notebook 正文，不递归读取其他工作区文件。
+- 执行结果只返回给调用方，默认且当前始终不保存回 Notebook。
+- 临时资源、超时、流式输出与强制 `--yes` 规则同 `research exec`。
+
 ---
 
 ## 七、错误处理
@@ -405,13 +565,16 @@ jqcli/
 │   │   ├── auth.py
 │   │   ├── strategy.py
 │   │   ├── backtest.py
-│   │   └── community.py
+│   │   ├── community.py
+│   │   ├── research.py
+│   │   └── research_execution.py
 │   ├── commands/
 │   │   ├── __init__.py
 │   │   ├── auth.py
 │   │   ├── strategy.py
 │   │   ├── backtest.py
-│   │   └── community.py
+│   │   ├── community.py
+│   │   └── research.py
 │   ├── config.py
 │   ├── errors.py
 │   └── output.py
@@ -440,7 +603,8 @@ jqcli/
 - 非交互测试：所有破坏性命令在 `--non-interactive` 且无 `--yes` 时必须失败。
 - JSON 测试：`--format json` 下 stdout 必须可被 `json.loads` 解析。
 - stdin 测试：只有显式 `--password-stdin`、`--code-stdin` 时才读取 stdin。
-- API 测试：使用 `pytest-httpx` 或 `respx` mock 聚宽响应，不访问真实服务。
+- API 测试：使用 `httpx.MockTransport` mock 聚宽响应，不访问真实服务。
+- 研究测试：覆盖 SSO 脱敏、跨域拒绝、cookie 更新、中文/空格路径编码、Contents 模型、三种下载格式、WebSocket 消息、输出预算、超时/异常清理和 JSONL 终止事件。
 - 回归测试：每个 MVP 命令至少覆盖一个成功路径和一个错误路径。
 
 ---
@@ -457,4 +621,8 @@ jqcli/
 8. `strategy new / edit`，支持 `--file` 和 `--code-stdin`。
 9. `backtest run / show / ls`。
 10. `strategy rm` 和可用时的 `backtest rm`，强制非交互确认规则。
-11. 真实账号手工验收，并更新 README 的接口风险说明。
+11. `research ls / show / download`，先完成只读 SSO 与 Contents API。
+12. 基于同版本官方契约实现 `research upload / mkdir / mv / rm`，只使用 mock 验证写路径。
+13. 只读确认 `research kernelspecs / kernels / sessions` 与 channels 路由开放，并与 Notebook 5.4.1 官方实现交叉验证。
+14. 实现独占临时会话/内核上的 `research exec / run`、执行事件收集、超时与 `finally` 清理；Notebook 默认不保存。
+15. 真实账号只读验收，并更新 README 的接口风险说明；临时执行验证仅在用户明确授权时进行。

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,20 +1,22 @@
 # jqcli 当前进度
 
-更新时间：2026-04-25
+更新时间：2026-08-15
 
 ## 已完成
 
-- 已创建项目虚拟环境 `.venv`，Python 版本为 `3.13.13`。
+- 已创建项目虚拟环境 `.venv`，Python 版本为 `3.13.5`。
 - 已实现基础 MVP：
   - `auth status/logout/import-token/import-cookie/login`
   - `strategy ls/show/new/edit/rm`
   - `backtest run/ls/show/rm`
+  - `research ls/show/download/upload/mkdir/mv/rm`
+  - `research kernelspecs/kernels/sessions/exec/run`
   - `--env-file` 和 `.env` 读取
   - `--non-interactive --format json`
   - 统一错误码和 JSON 错误输出
 - 已添加 `.env` 和 `.env.example`。
 - `.env` 已加入 `.gitignore`，避免提交真实账号密码。
-- 单元测试全量通过，最近一次结果为 `58 passed`。
+- 单元测试全量通过，最近一次结果为 `270 passed`。
 
 ## 真实聚宽登录调研
 
@@ -133,13 +135,38 @@
   - `/algorithm/index/AlgorithmToFile?...`
   - `/algorithm/index/GetFileList?...`
 
+## 研究平台支持
+
+- 2026-08-14 至 2026-08-15 完成研究工作区调研与实现：
+  - 研究平台不复用 `/algorithm/index/*File` 策略文件夹接口，也不是 Community 响应里的 `research.notebook_*` 元数据。
+  - 主站 Cookie 先读取 `/default/research/redirect`，通过同源 JupyterHub/OAuth 重定向建立会话，再从页面发现动态 `/user/<user>/` base path。
+  - 已实现 Contents 读取、下载、上传、建目录、移动/重命名和删除 API/CLI。
+  - 路径拒绝 `.`、`..`、空组件与 NUL；SSO 逐跳校验同源；写请求按实际 Contents 路径选择 `_xsrf`。
+  - 远端写命令均需确认；上传默认不覆盖，仅 `--force` 允许覆盖；根目录不能作为写目标。
+  - 已用真实账号只读验证 `research ls` 和元数据 `research show`，未读取正文，未发送任何研究资产写请求。
+  - 写接口契约依据实例自报的 Jupyter Notebook 5.4.1 同版本官方实现，当前只用 `httpx.MockTransport` 测试固化。
+  - 已确认研究实例开放同版本 Jupyter 内核与会话接口：
+    - `GET api/kernelspecs` 返回 `200`，规格数量为 `3`。
+    - `GET api/kernels` 与 `GET api/sessions` 均返回 `200`，探测时数量均为 `0`。
+    - 对随机且确定不存在的标准 UUID 进行普通 `GET api/kernels/<id>/channels` 返回 `404`；Notebook 5.4.1 官方源码确认该 channels 路由及 WebSocket 消息契约。
+    - 整个开放性探测保持只读，没有启动、连接或停止任何现有 kernel/session，也没有输出名称、标识或 Notebook 路径。
+  - 已增加只读 `research kernelspecs/kernels/sessions`，用于查看可用内核规格及当前内核/会话。
+  - 已增加 `research exec` 与 `research run`：
+    - `exec` 从 `--file` 或 `--code-stdin` 读取代码；`run` 执行用户明确指定的远端 Notebook，可重复传 `--cell` 选择零基索引单元。
+    - `exec` 与 `run` 都创建独占的高熵临时 session 与新内核；`exec` 的合成 session 不保存研究文件，两者绝不复用现有对象，并在成功、错误、超时或中断时从 `finally` 清理。
+    - 两个命令均强制显式 `--yes`；支持 `--kernel`、`--execution-timeout` 与 `--stream`。
+    - `run` 默认且当前始终不保存输出回远端 Notebook。
+  - 已完成最小真实远端执行验收：在独占高熵临时会话中执行 `1 + 1`，返回 `status=ok` 与结果 `2`；执行前后 kernel/session 数量均为 `0`。验收没有读取或保存 Notebook，也没有连接现有内核。
+  - wheel 打包已修正为包含 `jqcli.api`、`jqcli.commands`、`jqcli.web` 及 Web 静态资源。
+
 ## 重启后建议下一步
 
 1. 补强边界行为：
    - `backtest rm` 当前建议传 `backtest ls` 返回的 `list_id`；后续可增加详情 id 到列表 id 的自动解析。
    - `backtest ls` 的指标字段初始 HTML 里可能为 `--`，后续可调用 `/algorithm/backtest/statsList` 合并实时统计。
-2. 增加 README 命令示例和字段说明。
-3. 后续可补分页、文件夹策略同名冲突处理、更多错误码映射。
+2. 如需继续验证错误、超时或中断路径，应仍使用无资产写入的最小临时代码，并在前后比较 kernel/session 数量；不要复用或停止现有对象。
+3. 研究平台如需支持超过 25 MiB 文件，先根据真实实例只读证据补齐分块上传契约。
+4. 后续可补分页、文件夹策略同名冲突处理、更多错误码映射。
 
 ## 注意事项
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # jqcli
 
-聚宽（JoinQuant）策略与回测管理命令行工具。
+聚宽（JoinQuant）策略、回测与研究工作区管理命令行工具。
 
-`jqcli` 面向自动化调用和真实聚宽网页接口封装，支持认证、策略管理、正式回测、编译运行记录查询与删除、社区最新文章列表。所有命令都可以使用 `--non-interactive --format json` 作为机器可读主路径。
+`jqcli` 面向自动化调用和真实聚宽网页接口封装，支持认证、策略管理、正式回测、编译运行记录查询与删除、研究文件管理与远端执行、社区最新文章列表。所有命令都可以使用 `--non-interactive --format json` 作为机器可读主路径。
 
 ## 安装与运行
 
@@ -10,7 +10,7 @@
 
 ```bash
 python -m venv .venv
-.venv/bin/pip install -e ".[dev]"
+.venv/bin/pip install -e ".[test]"
 .venv/bin/jqcli --help
 ```
 
@@ -35,8 +35,8 @@ JQCLI_COOKIE=your_cookie
 
 凭据优先级：
 
-1. 命令行 `--token` / `--cookie`
-2. 环境变量 `JQCLI_TOKEN` / `JQCLI_COOKIE`
+1. 环境变量 `JQCLI_TOKEN` / `JQCLI_COOKIE`
+2. 命令行 `--token` / `--cookie`
 3. 本地配置文件中保存的 `token` / `cookie`
 4. `auth login` 使用 `JQCLI_USERNAME` / `JQCLI_PASSWORD` 或 stdin 密码登录后保存 cookie
 
@@ -1076,6 +1076,138 @@ jqcli --env-file .env --format json community clone-strategy <post_id> --backtes
 - `reason=deny`：积分不足或无权限
 - `secret` 不会输出，只返回 `secret_present`
 
+## Research API
+
+研究平台与策略接口不是同一套服务。聚宽的 `/research` 会先通过 `/default/research/redirect` 建立短期 JupyterHub 会话，再访问账号对应的 Jupyter Contents API。`jqcli` 复用 `auth login` 保存的网页 Cookie，并在内存中完成这次 SSO；一次性用户名、会话 token 和 Hub cookie 不会出现在命令输出中。
+
+这里的账号研究工作区也不同于 Community 输出里的 `research.notebook_*`：后者只是社区文章附带的 Notebook 元数据，不能用于管理“我的研究”文件。
+
+`ls` 和不带 `--content` 的 `show` 已经过真实账号只读验证，验收过程没有读取用户文件正文。下载的内容解码，以及上传、建目录、移动和删除，依据实例自报的 Jupyter Notebook 5.4.1 及其同版本官方 [Contents 客户端](https://github.com/jupyter/notebook/blob/5.4.1/notebook/static/services/contents.js) 与 [XSRF 实现](https://github.com/jupyter/notebook/blob/5.4.1/notebook/static/base/js/utils.js)契约，并由 mock 单元测试固化；这些远端文件写操作没有在真实账号上执行。
+
+同一实例还开放了 Jupyter 5.4.1 的 KernelSpec、Kernel、Session HTTP API 与 Kernel channels 路由。真实账号只读探测中，`kernelspecs` 返回 `200` 且共有 3 项，`kernels` 与 `sessions` 均返回 `200` 且为空列表；对随机、确定不存在的标准 UUID 发起普通 channels GET 返回 `404`。路由及消息契约同时以同版本官方 [Kernel 客户端](https://github.com/jupyter/notebook/blob/5.4.1/notebook/static/services/kernels/kernel.js)、[Session 客户端](https://github.com/jupyter/notebook/blob/5.4.1/notebook/static/services/sessions/session.js)、[Kernel handler](https://github.com/jupyter/notebook/blob/5.4.1/notebook/services/kernels/handlers.py) 与 [Session handler](https://github.com/jupyter/notebook/blob/5.4.1/notebook/services/sessions/handlers.py)为依据。只读探测没有启动、连接或停止任何现有内核。
+
+受控真实验收随后用独占临时会话执行了 `1 + 1`：WebSocket 执行状态为 `ok`，结果为 `2`；执行前后 `kernels` 与 `sessions` 数量均为 `0`。该验收没有读取或保存 Notebook，也没有连接现有内核。`exec`/`run` 的临时会话使用高熵合成路径，Jupyter Session API 只建立内存会话；即使创建响应丢失，jqcli 也只会按该精确合成路径找回并清理自己的会话。
+
+研究命令需要 Cookie 登录态；只有 Bearer token 时请先执行：
+
+```bash
+jqcli --env-file .env --format json auth login
+```
+
+### research ls
+
+列出研究根目录或指定子目录。远端路径始终使用 `/` 分隔；根目录可以省略或写成 `/`。
+
+```bash
+jqcli --format json research ls
+jqcli --format json research ls "因子研究/2026"
+```
+
+输出：
+
+```json
+{
+  "path": "因子研究/2026",
+  "items": [
+    {
+      "name": "示例研究.ipynb",
+      "path": "因子研究/2026/示例研究.ipynb",
+      "type": "notebook",
+      "writable": true,
+      "created": "2026-08-14T08:00:00Z",
+      "last_modified": "2026-08-14T09:00:00Z",
+      "mimetype": null,
+      "format": null,
+      "size": null
+    }
+  ],
+  "total": 1
+}
+```
+
+`type` 可能是 `directory`、`file` 或 `notebook`。列表只返回一层，不递归读取子目录或文件内容。
+
+### research show
+
+默认只读取资源元数据；传 `--content` 才请求正文。Notebook 正文保持 Jupyter JSON 模型，文本文件正文为字符串，二进制文件正文通常为 base64。
+
+```bash
+jqcli --format json research show "因子研究/示例.py"
+jqcli --format json research show "因子研究/示例.py" --content
+```
+
+### research download
+
+把普通文件或 Notebook 保存到本地。省略 `--output` 时使用远端文件名；目标已存在时默认失败，只有显式传 `--force` 才覆盖。本命令只写本地文件，不修改研究平台内容。
+
+```bash
+jqcli --format json research download "因子研究/示例.py" --output local/data/example.py
+jqcli --format json research download "因子研究/报告.ipynb" -o local/data/report.ipynb --force
+```
+
+文本按 UTF-8 保存，Notebook 按 JSON 保存，base64 文件会先解码。目录不能下载。
+
+### research kernelspecs / kernels / sessions
+
+只读查看聚宽研究实例公开的内核规格、当前内核与当前会话：
+
+```bash
+jqcli --format json research kernelspecs
+jqcli --format json research kernels
+jqcli --format json research sessions
+```
+
+这些命令不创建、连接、停止或复用任何内核/会话。自动化冒烟检查只应汇总数量和布尔状态，不应输出会话标识、Notebook 路径或其他用户资产信息。
+
+### research exec
+
+在聚宽研究环境中远端执行一段 Python 代码：
+
+```bash
+jqcli --non-interactive --format json research exec --file local/check.py --yes
+printf 'print(1 + 1)\n' | jqcli --non-interactive --format json research exec --code-stdin --yes
+jqcli --non-interactive --format json research exec --file local/check.py --kernel python3 --execution-timeout 120 --stream --yes
+```
+
+`--file` 与 `--code-stdin` 二选一。省略 `--kernel` 时使用服务器默认内核；`--execution-timeout` 只限制远端执行等待时间。`--stream` 仅支持 `--format json`，按到达顺序每行输出一个 JSON 事件，适合实时消费标准输出、展示结果和错误信息；最后一行固定为 `{"event":"done","result":{...}}`。
+
+远端代码可能读写文件、访问网络或消耗计算资源，因此该命令无论输出格式及是否为交互终端都必须显式传 `--yes`。每次调用只使用 jqcli 新建的独占临时会话及其新内核，不会连接或复用列表中的现有对象；成功、执行错误、超时及用户中断都会在 `finally` 路径清理临时资源。这个合成会话仅用于可靠追踪和清理内核，不会创建或保存研究文件。
+
+### research run
+
+远端执行已有 Notebook 的代码单元，默认按原始顺序运行全部代码单元；可重复传 `--cell` 只运行指定的零基索引单元：
+
+```bash
+jqcli --non-interactive --format json research run "因子研究/报告.ipynb" --yes
+jqcli --non-interactive --format json research run "因子研究/报告.ipynb" --cell 0 --cell 3 --execution-timeout 300 --yes
+jqcli --non-interactive --format json research run "因子研究/报告.ipynb" --kernel python3 --stream --yes
+```
+
+`--execution-timeout` 与 `--stream` 的语义同 `research exec`。未传 `--kernel` 时，`run` 优先使用 Notebook `metadata.kernelspec.name`，缺失时再使用平台默认内核。`run` 会读取用户明确指定的 Notebook 正文，并在独占临时会话/内核中执行选定单元；它默认且当前始终不把输出保存回远端 Notebook，也不会修改任何现有会话或内核。由于 Notebook 代码本身仍可能产生远端副作用，`--yes` 同样是必需参数。
+
+### research upload
+
+上传本地文件。省略远端路径时使用本地 basename；`.ipynb` 以 Notebook JSON 上传，UTF-8 文件以文本上传，其他文件使用 base64。
+
+```bash
+jqcli --format json research upload local/factor.py "因子研究/factor.py" --yes
+jqcli --non-interactive --format json research upload local/report.ipynb "报告/report.ipynb" --yes
+```
+
+远端目标已存在时默认失败；同时传 `--force` 才允许覆盖。非交互模式或 `--format json` 必须显式传 `--yes`；交互式 table 模式不传时会要求确认。当前不实现大文件分块上传；请把单个上传文件控制在 25 MiB 以内。
+
+### research mkdir / mv / rm
+
+创建目录、移动/重命名资源和删除资源：
+
+```bash
+jqcli --non-interactive --format json research mkdir "因子研究/2026" --yes
+jqcli --non-interactive --format json research mv "旧路径/demo.py" "新路径/demo.py" --yes
+jqcli --non-interactive --format json research rm "临时/demo.py" --yes
+```
+
+这三类命令会修改远端研究资产；非交互模式或 `--format json` 必须传 `--yes`，交互式 table 模式会要求确认。根目录不能作为创建、移动或删除目标。删除语义由聚宽当前 Jupyter Contents 实现决定，CLI 不承诺资源一定进入可恢复的回收站。
+
 ## 状态与错误码
 
 回测列表状态映射：
@@ -1104,11 +1236,14 @@ jqcli --env-file .env --format json community clone-strategy <post_id> --backtes
 
 ## 真实测试记录
 
-截至 2026-04-25，已用真实聚宽账号验证：
+截至 2026-08-15，已用真实聚宽账号验证：
 
 - `auth login/status/logout/import-cookie`
 - `strategy ls/show/new/edit/rm`
 - `backtest run/ls/show/rm`
+- `research ls/show`（只读取目录与元数据，不读取或修改文件正文）
+- `research kernelspecs/kernels/sessions`（只汇总数量和可用性；探测时现有内核、会话均为 0）
+- `research exec`（仅执行 `1 + 1` 的独占临时会话；返回 `ok`/`2`，执行后内核与会话数量恢复为 0）
 - 默认正式回测进入 `/algorithm/backtest/list`
 - `--compile` 编译运行使用 `/algorithm/backtest/buildList`
 
@@ -1138,7 +1273,9 @@ jqcli --env-file .env --format json community clone-strategy <post_id> --backtes
 .venv/bin/python -m pytest
 ```
 
-当前测试覆盖 API 解析、CLI 参数、非交互确认、JSON 输出和配置读取。
+当前测试覆盖 API/SSO 解析、研究路径编码与下载、临时内核/会话执行和清理、CLI 参数、非交互确认、JSON/流式输出和配置读取。
+
+最近一次全量结果为 `270 passed`；另已用 Python 3.9 完成源码语法编译，并验证 wheel 包含 `jqcli.api`、`jqcli.commands`、`jqcli.web` 与静态资源。
 
 ## Codex Skill
 
@@ -1150,6 +1287,6 @@ Install it into the local Codex skills directory:
 .\scripts\install_codex_skill.ps1
 ```
 
-The skill teaches Codex to use the jqcli console entry point, run local and API tests, perform read-only live JoinQuant smoke checks, and run a temporary compile-only write smoke check when explicitly approved.
+The skill teaches Codex to use the jqcli console entry point, run local and API tests, inspect the research workspace and kernel/session availability without exposing identifiers, file names, or contents in smoke summaries, perform read-only live JoinQuant checks, and run explicitly approved temporary execution or compile-only checks with guaranteed cleanup.
 
 Local data, experiments, logs, marketing assets, and local-only helper scripts belong under `local/`, which is ignored by git.

--- a/codex-skill/jqcli/SKILL.md
+++ b/codex-skill/jqcli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jqcli
-description: "Use when Codex needs to operate or maintain the jqcli JoinQuant project: authenticate, inspect strategies, list or run backtests, archive community posts, validate jqcli API behavior, run local tests, perform live JoinQuant smoke checks, or troubleshoot jqcli CLI/API workflows."
+description: "Use when Codex needs to operate or maintain the jqcli JoinQuant project: authenticate, inspect strategies or research files, discover research kernels and sessions, run explicitly approved temporary research code or notebooks, list or run backtests, archive community posts, validate jqcli API behavior, run local tests, perform live JoinQuant smoke checks, or troubleshoot jqcli CLI/API workflows."
 ---
 
 # jqcli
@@ -64,6 +64,12 @@ Prefer read-only live checks before write checks. Run write smoke checks only wh
 For write smoke checks, create a temporary strategy, run compile-only backtest, read result/logs, delete the compile record, and delete the temporary strategy.
 
 Never run `strategy rm`, `backtest rm`, `strategy edit`, or `backtest run` against user assets unless the command targets a temporary smoke-test object or the user explicitly identifies the target.
+
+Research smoke checks are read-only. Prefer `research ls`, metadata-only `research show`, and `research kernelspecs/kernels/sessions`; report only counts and booleans, never research paths, file names, contents, kernel/session identifiers, or kernel-spec names.
+
+Never run `research upload`, `research mkdir`, `research mv`, or `research rm` against user assets during a smoke check. Use those commands only when the user explicitly identifies the target or approves a temporary research object and its cleanup.
+
+Never include `research exec` or `research run` in the standard read-only smoke check. Remote code can have arbitrary side effects, so run it only when the user explicitly approves execution, always pass `--yes`, and use the minimum code or explicitly named Notebook required by the task. Both commands create an exclusive high-entropy temporary session and new kernel; the `exec` session does not save a research file. jqcli cleans them up, never reuses existing objects, and does not save `research run` outputs back to the Notebook.
 
 ## Verification
 

--- a/codex-skill/jqcli/references/api-workflows.md
+++ b/codex-skill/jqcli/references/api-workflows.md
@@ -30,7 +30,14 @@ It checks:
 - `strategy ls`
 - if available, `strategy show`
 - if available, `backtest ls/show/stats/result/logs`
+- `research ls`
+- if available, metadata-only `research show`
+- `research kernelspecs`
+- `research kernels`
+- `research sessions`
 - `community clone-strategy` in non-executing check mode when a post with a backtest is found
+
+The script reports only counts and booleans for research checks; it does not echo user paths, file names, contents, kernel/session identifiers, or kernel-spec names. It never calls `research exec` or `research run`.
 
 ## Write Live Smoke Check
 
@@ -74,3 +81,58 @@ Backtests:
 .\.venv\Scripts\jqcli.exe --format json --non-interactive backtest result <backtest_id>
 .\.venv\Scripts\jqcli.exe --format json --non-interactive backtest logs <backtest_id> --offset 0
 ```
+
+Research (read-only):
+
+```powershell
+.\.venv\Scripts\jqcli.exe --format json --non-interactive research ls
+.\.venv\Scripts\jqcli.exe --format json --non-interactive research show <remote_path>
+.\.venv\Scripts\jqcli.exe --format json --non-interactive research kernelspecs
+.\.venv\Scripts\jqcli.exe --format json --non-interactive research kernels
+.\.venv\Scripts\jqcli.exe --format json --non-interactive research sessions
+```
+
+Keep `research show` metadata-only during live smoke checks; do not pass `--content` unless the user explicitly asks to read that file.
+
+The kernel/session discovery commands are read-only. Summarize only their counts and success/default-present booleans; do not print identifiers, paths, or kernel-spec names.
+
+Research mutations are never part of the standard smoke check. Only when the user explicitly identifies or approves a target:
+
+```powershell
+.\.venv\Scripts\jqcli.exe --format json --non-interactive research upload <local_path> <remote_path> --yes
+.\.venv\Scripts\jqcli.exe --format json --non-interactive research mkdir <remote_path> --yes
+.\.venv\Scripts\jqcli.exe --format json --non-interactive research mv <source> <destination> --yes
+.\.venv\Scripts\jqcli.exe --format json --non-interactive research rm <remote_path> --yes
+```
+
+Use `--force` with `research upload` only when the user explicitly approves overwriting the existing remote path.
+
+## Research Remote Execution
+
+Remote execution is never part of a standard smoke check. Run it only when the user explicitly asks for or approves remote execution, because executed code may modify files, access the network, or consume remote resources.
+
+Execute a local code file or explicit stdin payload:
+
+```powershell
+.\.venv\Scripts\jqcli.exe --format json --non-interactive research exec --file <local.py> --yes
+Get-Content -Raw -Encoding utf8 <local.py> | .\.venv\Scripts\jqcli.exe --format json --non-interactive research exec --code-stdin --yes
+```
+
+Execute an explicitly identified remote Notebook, optionally selecting zero-based cells:
+
+```powershell
+.\.venv\Scripts\jqcli.exe --format json --non-interactive research run <remote.ipynb> --yes
+.\.venv\Scripts\jqcli.exe --format json --non-interactive research run <remote.ipynb> --cell 0 --cell 2 --yes
+```
+
+Optional execution controls:
+
+```text
+--kernel <name>
+--execution-timeout <seconds>
+--stream
+```
+
+`--stream` requires `--format json`. It emits one JSON object per line in arrival order and always finishes with `{"event":"done","result":{...}}` on success.
+
+Always pass `--yes`; interactive mode does not replace this approval. Both commands use a new exclusive high-entropy temporary session and kernel; the `exec` session is only for reliable ownership and cleanup and does not save a research file. Allow the command to reach its cleanup path. `research run` reads the explicitly named Notebook but does not save outputs back to it. After an interrupted or failed live validation, rerun the read-only `research kernels` and `research sessions` commands and compare counts with the pre-run baseline; do not stop unrelated existing objects.

--- a/codex-skill/jqcli/references/troubleshooting.md
+++ b/codex-skill/jqcli/references/troubleshooting.md
@@ -65,6 +65,19 @@ Symptom:
 
 Treat this as a live service response, not a local parser failure. Retry once after a short wait. If it persists, report it separately from local test results.
 
+## Research Execution Timeout Or Channel Failure
+
+If `research exec` or `research run` times out or reports a WebSocket/channel error, preserve the original error and let jqcli finish its `finally` cleanup. Do not attach to, interrupt, or delete a kernel/session returned by the read-only list unless it was created by the current invocation.
+
+After the command returns, compare read-only counts with a baseline:
+
+```powershell
+.\.venv\Scripts\jqcli.exe --format json --non-interactive research kernels
+.\.venv\Scripts\jqcli.exe --format json --non-interactive research sessions
+```
+
+Report counts and cleanup status only; do not include identifiers, Notebook paths, code, or output unless the user explicitly requested those details. `research run` never saves execution outputs back to the remote Notebook.
+
 ## Local Data Paths
 
 Expected ignored local state:

--- a/codex-skill/jqcli/scripts/smoke_readonly.ps1
+++ b/codex-skill/jqcli/scripts/smoke_readonly.ps1
@@ -1,4 +1,9 @@
 $ErrorActionPreference = "Stop"
+$Utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[Console]::InputEncoding = $Utf8NoBom
+[Console]::OutputEncoding = $Utf8NoBom
+$OutputEncoding = $Utf8NoBom
+$env:PYTHONUTF8 = "1"
 
 function Find-JqcliRepo {
     $Candidates = @()
@@ -41,9 +46,17 @@ if (-not (Test-Path -LiteralPath $Jqcli)) {
 function Invoke-JqcliJson {
     param([string[]] $Command)
 
-    $Output = & $Jqcli @BaseArgs @Command 2>&1
-    if ($LASTEXITCODE -ne 0) {
-        throw "jqcli $($Command -join ' ') failed: $Output"
+    $PreviousErrorAction = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "Continue"
+        $Output = & $Jqcli @BaseArgs @Command 2>&1
+        $ExitCode = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $PreviousErrorAction
+    }
+    if ($ExitCode -ne 0) {
+        $Operation = (@($Command) | Select-Object -First 2) -join " "
+        throw "jqcli $Operation failed with exit code $ExitCode"
     }
     return ($Output | Out-String | ConvertFrom-Json)
 }
@@ -88,6 +101,39 @@ if ($StrategyId) {
         $Summary.backtest_result_ok = [bool] $Result.id
         $Summary.backtest_logs_ok = $null -ne $Logs.logs
     }
+}
+
+$Research = $null
+try {
+    $Research = Invoke-JqcliJson @("research", "ls")
+} catch {
+    if ($_.Exception.Message -match "exit code 1$") {
+        $Summary.research_skipped_not_authenticated = $true
+    } else {
+        throw
+    }
+}
+
+if ($null -ne $Research) {
+    $Summary.research_count = @($Research.items).Count
+    $ResearchPath = if (@($Research.items).Count -gt 0) { [string] $Research.items[0].path } else { $null }
+    $Summary.research_first_path_present = [bool] $ResearchPath
+
+    if ($ResearchPath) {
+        $ResearchItem = Invoke-JqcliJson @("research", "show", $ResearchPath)
+        $Summary.research_show_ok = [bool] $ResearchItem.type
+        $Summary.research_content_requested = $false
+    }
+
+    $KernelSpecs = Invoke-JqcliJson @("research", "kernelspecs")
+    $Kernels = Invoke-JqcliJson @("research", "kernels")
+    $Sessions = Invoke-JqcliJson @("research", "sessions")
+    $Summary.research_kernelspec_count = [int] $KernelSpecs.total
+    $Summary.research_default_kernelspec_present = [bool] $KernelSpecs.default
+    $Summary.research_kernel_count = [int] $Kernels.total
+    $Summary.research_kernels_query_ok = $null -ne $Kernels.total
+    $Summary.research_session_count = [int] $Sessions.total
+    $Summary.research_sessions_query_ok = $null -ne $Sessions.total
 }
 
 $Cloneable = $null

--- a/jqcli/api/client.py
+++ b/jqcli/api/client.py
@@ -1,10 +1,46 @@
 from __future__ import annotations
 
+import secrets
+from http.cookiejar import Cookie as JarCookie
+from http.cookies import CookieError, SimpleCookie
 from typing import Any
+from urllib.parse import urlsplit
 
 import httpx
 
 from jqcli.errors import ApiError, NetworkError, NotAuthenticatedError, NotFoundError
+
+
+def _cookie_segments(value: str | None) -> list[tuple[str, str]]:
+    """Split a Cookie header without decoding, deduplicating, or rewriting it."""
+    if not value:
+        return []
+
+    raw_segments: list[str] = []
+    start = 0
+    quote: str | None = None
+    escaped = False
+    for index, character in enumerate(value):
+        if escaped:
+            escaped = False
+        elif quote is not None and character == "\\":
+            escaped = True
+        elif quote is not None and character == quote:
+            quote = None
+        elif quote is None and character == '"':
+            quote = character
+        elif quote is None and character == ";":
+            raw_segments.append(value[start:index].strip())
+            start = index + 1
+    raw_segments.append(value[start:].strip())
+
+    parsed: list[tuple[str, str]] = []
+    for segment in raw_segments:
+        name, separator, _ = segment.partition("=")
+        name = name.strip()
+        if separator and name and not name.startswith("$"):
+            parsed.append((name, segment))
+    return parsed
 
 
 class ApiClient:
@@ -20,10 +56,47 @@ class ApiClient:
         self.api_base = api_base.rstrip("/")
         self.token = token
         self.cookie = cookie
-        self._client = httpx.Client(base_url=self.api_base, timeout=timeout, transport=transport, trust_env=False)
+        self._initial_cookie_header = cookie
+        self._shadowed_initial_cookie_names: set[str] = set()
+        self._client = httpx.Client(
+            base_url=self.api_base,
+            timeout=timeout,
+            transport=transport,
+            trust_env=False,
+        )
 
     def close(self) -> None:
         self._client.close()
+
+    def get_cookie(self, name: str, path: str = "/") -> str | None:
+        """Return the server-visible value from a same-origin request Cookie header."""
+        self._validate_request_target(path)
+        header = self._cookie_header_for(path)
+        value: str | None = None
+        for cookie_name, segment in _cookie_segments(header):
+            if cookie_name == name:
+                # Tornado/SimpleCookie resolves duplicate request Cookie names by
+                # keeping the last value, so the XSRF header must do the same.
+                value = segment.partition("=")[2]
+        if header:
+            parsed = SimpleCookie()
+            try:
+                parsed.load(header)
+            except CookieError:
+                parsed.clear()
+            if name in parsed:
+                return parsed[name].value
+        return value
+
+    def get_cookie_header(self, path: str = "/") -> str | None:
+        """Return the Cookie header for a same-origin target.
+
+        This is intentionally a getter rather than a property: cookie Path and
+        Secure matching depend on the target URL.  Callers must treat the return
+        value as a secret and must never include it in results or exceptions.
+        """
+        self._validate_request_target(path)
+        return self._cookie_header_for(path)
 
     def __enter__(self) -> ApiClient:
         return self
@@ -35,23 +108,155 @@ class ApiClient:
         headers: dict[str, str] = {"X-Requested-With": "XMLHttpRequest"}
         if self.token:
             headers["Authorization"] = f"Bearer {self.token}"
-        if self.cookie:
-            headers["Cookie"] = self.cookie
         return headers
 
     def _send(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
-        headers = {**self._headers(), **kwargs.pop("headers", {})}
+        allow_redirect_status = bool(kwargs.pop("_allow_redirect_status", False))
+        self._validate_request_target(path)
+        if kwargs.get("follow_redirects"):
+            raise ApiError("ApiClient 不允许自动跟随重定向，请显式校验目标地址")
+        headers = self._headers()
+        cookie_header = self._cookie_header_for(path)
+        if cookie_header:
+            headers["Cookie"] = cookie_header
+        headers.update(kwargs.pop("headers", {}))
         try:
             response = self._client.request(method, path, headers=headers, **kwargs)
         except httpx.RequestError as exc:
             raise NetworkError() from exc
+        self._remember_initial_cookie_mutations(response)
         if response.status_code in (401, 403):
             raise NotAuthenticatedError("登录已过期或凭据无效")
         if response.status_code == 404:
             raise NotFoundError("资源不存在")
+        if 300 <= response.status_code < 400 and not allow_redirect_status:
+            location = response.headers.get("location", "").lower()
+            if "/user/login" in location or "/hub/login" in location:
+                raise NotAuthenticatedError("登录已过期，请重新执行认证命令")
+            raise ApiError(f"请求返回了意外重定向（HTTP {response.status_code}）", status_code=response.status_code)
         if response.status_code >= 400:
             raise ApiError(f"请求失败（HTTP {response.status_code}）", status_code=response.status_code)
         return response
+
+    def _cookie_header_for(self, path: str) -> str | None:
+        target = httpx.URL(path)
+        if target.is_relative_url:
+            target = self._client.base_url.join(target)
+
+        probe = httpx.Request("GET", target)
+        self._client.cookies.set_cookie_header(probe)
+        session_header = probe.headers.get("cookie")
+        initial_header = self._initial_cookie_header
+        if not initial_header:
+            return session_header
+        session_names = {name for name, _ in _cookie_segments(session_header)}
+        # A browser-exported Cookie header has no Domain/Path metadata.  Model
+        # its entries as host-only, Path=/ values.  Once the server accepts an
+        # update or deletion for that exact scope, the imported value must never
+        # reappear after the session value expires.
+        replacement_names = set(self._shadowed_initial_cookie_names)
+        if not session_header and not replacement_names:
+            # Preserve browser-exported values byte-for-byte, including duplicate
+            # names and quoted escape sequences used by existing commands.
+            return initial_header
+
+        initial_names = {name for name, _ in _cookie_segments(initial_header)}
+        if replacement_names.isdisjoint(initial_names) and session_names.isdisjoint(initial_names):
+            if not session_header:
+                return initial_header
+            return f"{initial_header}; {session_header}"
+        initial_pairs = [
+            (name, segment)
+            for name, segment in _cookie_segments(initial_header)
+            if name not in replacement_names
+        ]
+        if not initial_pairs:
+            return session_header
+        if not session_header:
+            return "; ".join(segment for _, segment in initial_pairs)
+
+        session_pairs = _cookie_segments(session_header)
+        initial_by_name: dict[str, list[str]] = {}
+        session_by_name: dict[str, list[str]] = {}
+        ordered_names: list[str] = []
+        for name, segment in initial_pairs:
+            initial_by_name.setdefault(name, []).append(segment)
+            if name not in ordered_names:
+                ordered_names.append(name)
+        for name, segment in session_pairs:
+            session_by_name.setdefault(name, []).append(segment)
+            if name not in ordered_names:
+                ordered_names.append(name)
+
+        narrow_counts = self._narrow_session_cookie_counts(target)
+        merged: list[str] = []
+        for name in ordered_names:
+            initial_values = initial_by_name.get(name, [])
+            session_values = session_by_name.get(name, [])
+            if initial_values and session_values:
+                split = min(narrow_counts.get(name, 0), len(session_values))
+                merged.extend(session_values[:split])
+                merged.extend(initial_values)
+                merged.extend(session_values[split:])
+            else:
+                merged.extend(initial_values or session_values)
+        return "; ".join(merged)
+
+    def _narrow_session_cookie_counts(self, target: httpx.URL) -> dict[str, int]:
+        host = (target.host or "").lower()
+        request_path = target.path or "/"
+        secure_request = target.scheme.lower() == "https"
+        counts: dict[str, int] = {}
+        for item in self._client.cookies.jar:
+            cookie_path = item.path or "/"
+            if (
+                cookie_path != "/"
+                and _cookie_domain_matches(host, item.domain, not item.domain_specified)
+                and _cookie_path_matches(request_path, cookie_path)
+                and (not item.secure or secure_request)
+            ):
+                counts[item.name] = counts.get(item.name, 0) + 1
+        return counts
+
+    def _remember_initial_cookie_mutations(self, response: httpx.Response) -> None:
+        initial_names = {name for name, _ in _cookie_segments(self._initial_cookie_header)}
+        for name in initial_names.difference(self._shadowed_initial_cookie_names):
+            sentinel = secrets.token_hex(16)
+            probe = httpx.Cookies()
+            probe.jar.set_cookie(_host_root_cookie(name, sentinel, response.url.host or ""))
+            probe.extract_cookies(response)
+            sentinel_survived = any(
+                item.name == name
+                and item.value == sentinel
+                and not item.domain_specified
+                and (item.path or "/") == "/"
+                for item in probe.jar
+            )
+            if not sentinel_survived:
+                self._shadowed_initial_cookie_names.add(name)
+
+    def _validate_request_target(self, path: str) -> None:
+        try:
+            target = urlsplit(str(path))
+            if not (target.scheme or target.netloc):
+                return
+            if target.username is not None or target.password is not None or target.fragment:
+                raise ApiError("拒绝包含用户信息或片段的 API 请求地址")
+            base = urlsplit(self.api_base)
+            if _origin(target) != _origin(base):
+                raise ApiError("拒绝向 API 基地址以外的主机发送请求")
+        except (UnicodeError, ValueError):
+            raise ApiError("API 请求地址无效") from None
+
+    def request_response(
+        self,
+        method: str,
+        path: str,
+        *,
+        allow_redirect_status: bool = False,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        return self._send(method, path, _allow_redirect_status=allow_redirect_status, **kwargs)
 
     def request(self, method: str, path: str, **kwargs: Any) -> Any:
         response = self._send(method, path, **kwargs)
@@ -78,5 +283,53 @@ class ApiClient:
     def put(self, path: str, **kwargs: Any) -> Any:
         return self.request("PUT", path, **kwargs)
 
+    def patch(self, path: str, **kwargs: Any) -> Any:
+        return self.request("PATCH", path, **kwargs)
+
     def delete(self, path: str, **kwargs: Any) -> Any:
         return self.request("DELETE", path, **kwargs)
+
+
+def _origin(value: Any) -> tuple[str, str, int | None]:
+    scheme = value.scheme.lower()
+    port = value.port
+    if port is None:
+        port = 443 if scheme == "https" else 80 if scheme == "http" else None
+    return scheme, (value.hostname or "").lower(), port
+
+
+def _host_root_cookie(name: str, value: str, host: str) -> JarCookie:
+    return JarCookie(
+        version=0,
+        name=name,
+        value=value,
+        port=None,
+        port_specified=False,
+        domain=host.lower(),
+        domain_specified=False,
+        domain_initial_dot=False,
+        path="/",
+        path_specified=True,
+        secure=False,
+        expires=None,
+        discard=True,
+        comment=None,
+        comment_url=None,
+        rest={},
+        rfc2109=False,
+    )
+
+
+def _cookie_domain_matches(host: str, domain: str, host_only: bool) -> bool:
+    normalized_domain = domain.lstrip(".").lower()
+    if host_only:
+        return host == normalized_domain
+    return host == normalized_domain or host.endswith(f".{normalized_domain}")
+
+
+def _cookie_path_matches(request_path: str, cookie_path: str) -> bool:
+    if request_path == cookie_path:
+        return True
+    if not request_path.startswith(cookie_path):
+        return False
+    return cookie_path.endswith("/") or request_path[len(cookie_path)] == "/"

--- a/jqcli/api/research.py
+++ b/jqcli/api/research.py
@@ -1,0 +1,419 @@
+from __future__ import annotations
+
+import json
+import re
+from html import unescape
+from html.parser import HTMLParser
+from typing import Any
+from urllib.parse import quote, unquote, urljoin, urlsplit
+
+from jqcli.errors import ApiError, NotAuthenticatedError, UsageError
+
+from .client import ApiClient
+
+
+_JS_STRING = r'''(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')'''
+_SSO_REDIRECT_STATUSES = {301, 302, 303, 307, 308}
+_MAX_SSO_REDIRECTS = 12
+_RESEARCH_ITEM_FIELDS = (
+    "name",
+    "path",
+    "type",
+    "writable",
+    "created",
+    "last_modified",
+    "mimetype",
+    "format",
+    "size",
+)
+
+
+class _BaseUrlParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.values: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag.lower() != "body":
+            return
+        for name, value in attrs:
+            if name.lower() == "data-base-url" and value is not None:
+                self.values.append(value)
+
+
+def normalize_research_path(path: str) -> str:
+    """Return the canonical, root-relative path accepted by Jupyter Contents."""
+    if not isinstance(path, str):
+        raise UsageError("研究平台路径必须是字符串")
+
+    normalized = path.replace("\\", "/").strip("/")
+    if not normalized:
+        return ""
+
+    components = normalized.split("/")
+    if any(component in {"", ".", ".."} or "\x00" in component for component in components):
+        raise UsageError("研究平台路径包含无效组件")
+    return "/".join(components)
+
+
+def list_research_items(client: ApiClient, path: str = "") -> dict[str, Any]:
+    normalized_path = normalize_research_path(path)
+    base_path = _bootstrap_research(client)
+    payload = _get_contents(client, base_path, normalized_path, include_content=True)
+    content = payload.get("content")
+    if payload.get("type") != "directory" or not isinstance(content, list):
+        raise ApiError("研究平台返回了无效的目录内容")
+
+    items = [_normalize_item(item, include_content=False) for item in content]
+    return {"path": normalized_path, "items": items, "total": len(items)}
+
+
+def get_research_item(client: ApiClient, path: str, include_content: bool = False) -> dict[str, Any]:
+    normalized_path = normalize_research_path(path)
+    base_path = _bootstrap_research(client)
+    payload = _get_contents(client, base_path, normalized_path, include_content=include_content)
+    return _normalize_item(payload, include_content=include_content)
+
+
+def save_research_item(
+    client: ApiClient,
+    path: str,
+    *,
+    content: Any,
+    item_type: str,
+    content_format: str,
+) -> dict[str, Any]:
+    normalized_path = _normalize_write_path(path)
+    _validate_save_payload(content, item_type=item_type, content_format=content_format)
+    base_path, xsrf_token = _prepare_research_write(client, normalized_path)
+    payload = client.put(
+        _contents_endpoint(base_path, normalized_path),
+        json={"type": item_type, "format": content_format, "content": content},
+        headers={"X-XSRFToken": xsrf_token},
+    )
+    return _normalize_item(payload, include_content=False)
+
+
+def create_research_directory(client: ApiClient, path: str) -> dict[str, Any]:
+    normalized_path = _normalize_write_path(path)
+    base_path, xsrf_token = _prepare_research_write(client, normalized_path)
+    payload = client.put(
+        _contents_endpoint(base_path, normalized_path),
+        json={"type": "directory"},
+        headers={"X-XSRFToken": xsrf_token},
+    )
+    return _normalize_item(payload, include_content=False)
+
+
+def move_research_item(client: ApiClient, path: str, destination: str) -> dict[str, Any]:
+    normalized_path = _normalize_write_path(path)
+    normalized_destination = _normalize_write_path(destination)
+    base_path, xsrf_token = _prepare_research_write(client, normalized_path)
+    payload = client.patch(
+        _contents_endpoint(base_path, normalized_path),
+        json={"path": normalized_destination},
+        headers={"X-XSRFToken": xsrf_token},
+    )
+    return _normalize_item(payload, include_content=False)
+
+
+def delete_research_item(client: ApiClient, path: str) -> None:
+    normalized_path = _normalize_write_path(path)
+    base_path, xsrf_token = _prepare_research_write(client, normalized_path)
+    response = client.request_response(
+        "DELETE",
+        _contents_endpoint(base_path, normalized_path),
+        headers={"X-XSRFToken": xsrf_token},
+    )
+    if response.status_code != 204:
+        raise ApiError(f"研究平台删除返回了意外状态（HTTP {response.status_code}）")
+    return None
+
+
+def _bootstrap_research(client: ApiClient) -> str:
+    script = client.get_text("/default/research/redirect")
+    mob, session_id, login_url = _parse_sso_script(script)
+    validated_login_url = _validate_sso_url(client.api_base, login_url)
+
+    login_html = _submit_sso_login(client, validated_login_url, mob=mob, session_id=session_id)
+    return _parse_base_path(login_html)
+
+
+def _submit_sso_login(client: ApiClient, login_url: str, *, mob: str, session_id: str) -> str:
+    method = "POST"
+    target = login_url
+    form: dict[str, str] | None = {"username": mob, "token": session_id}
+
+    for _ in range(_MAX_SSO_REDIRECTS + 1):
+        kwargs: dict[str, Any] = {"data": form} if form is not None else {}
+        response = client.request_response(
+            method,
+            target,
+            allow_redirect_status=True,
+            **kwargs,
+        )
+        if response.status_code not in _SSO_REDIRECT_STATUSES:
+            if 300 <= response.status_code < 400:
+                raise ApiError(f"研究平台返回了不支持的重定向（HTTP {response.status_code}）")
+            return response.text
+
+        location = response.headers.get("location")
+        if not location:
+            raise ApiError("研究平台登录重定向缺少目标地址")
+        target = _validate_sso_url(client.api_base, urljoin(str(response.url), location))
+
+        if response.status_code == 303 or (response.status_code in {301, 302} and method != "GET"):
+            method = "GET"
+            form = None
+
+    raise ApiError("研究平台登录重定向次数过多")
+
+
+def _parse_sso_script(script: str) -> tuple[str, str, str]:
+    try:
+        mob = _extract_js_assignment(script, "mob")
+        session_id = _extract_js_assignment(script, "sessionId")
+        call = re.search(
+            rf"\bCy\s*\.\s*postRedirect\s*\(\s*(?P<url>{_JS_STRING})\s*,\s*"
+            rf"(?P<form>\{{.*?\}}|[A-Za-z_$][\w$]*)\s*\)",
+            script,
+            flags=re.DOTALL,
+        )
+        if call is None:
+            raise ValueError
+        form = _resolve_sso_form(script, call.group("form"))
+        if not _has_js_binding(form, "username", "mob") or not _has_js_binding(form, "token", "sessionId"):
+            raise ValueError
+        login_url = _decode_js_string(call.group("url"))
+        if not mob or not session_id or not login_url:
+            raise ValueError
+    except (TypeError, ValueError):
+        # Never include the script: it contains the user's login identifier and
+        # one-time SSO token.
+        raise NotAuthenticatedError("无法获取有效的研究平台登录信息") from None
+    return mob, session_id, login_url
+
+
+def _resolve_sso_form(script: str, expression: str) -> str:
+    value = expression.strip()
+    if value.startswith("{") and value.endswith("}"):
+        return value[1:-1]
+    if re.fullmatch(r"[A-Za-z_$][\w$]*", value) is None:
+        raise ValueError
+    assignment = re.search(
+        rf"\b(?:var|let|const)\s+{re.escape(value)}\s*=\s*\{{(?P<form>.*?)\}}\s*;?",
+        script,
+        flags=re.DOTALL,
+    )
+    if assignment is None:
+        raise ValueError
+    return assignment.group("form")
+
+
+def _extract_js_assignment(script: str, name: str) -> str:
+    match = re.search(rf"\bvar\s+{re.escape(name)}\s*=\s*(?P<value>{_JS_STRING})\s*;", script)
+    if match is None:
+        raise ValueError
+    return _decode_js_string(match.group("value"))
+
+
+def _has_js_binding(value: str, key: str, variable: str) -> bool:
+    key_pattern = rf'''(?:["']{re.escape(key)}["']|\b{re.escape(key)}\b)'''
+    return re.search(rf"{key_pattern}\s*:\s*\b{re.escape(variable)}\b", value) is not None
+
+
+def _decode_js_string(literal: str) -> str:
+    if len(literal) < 2 or literal[0] not in {'"', "'"} or literal[-1] != literal[0]:
+        raise ValueError
+    value = literal[1:-1]
+    decoded: list[str] = []
+    simple_escapes = {
+        "b": "\b",
+        "f": "\f",
+        "n": "\n",
+        "r": "\r",
+        "t": "\t",
+        "v": "\v",
+        "0": "\x00",
+    }
+    index = 0
+    while index < len(value):
+        character = value[index]
+        if character != "\\":
+            decoded.append(character)
+            index += 1
+            continue
+        index += 1
+        if index >= len(value):
+            raise ValueError
+        escape = value[index]
+        if escape in simple_escapes:
+            decoded.append(simple_escapes[escape])
+            index += 1
+        elif escape in {"x", "u"}:
+            width = 2 if escape == "x" else 4
+            digits = value[index + 1 : index + 1 + width]
+            if len(digits) != width or re.fullmatch(r"[0-9a-fA-F]+", digits) is None:
+                raise ValueError
+            decoded.append(chr(int(digits, 16)))
+            index += width + 1
+        elif escape in {"\n", "\r"}:
+            # JavaScript line continuation.
+            if escape == "\r" and index + 1 < len(value) and value[index + 1] == "\n":
+                index += 1
+            index += 1
+        else:
+            decoded.append(escape)
+            index += 1
+    result = "".join(decoded)
+    if any(0xD800 <= ord(character) <= 0xDFFF for character in result):
+        raise ValueError
+    return result
+
+
+def _validate_sso_url(api_base: str, login_url: str) -> str:
+    try:
+        if any(ord(character) < 0x20 or ord(character) == 0x7F for character in login_url):
+            raise ValueError
+        absolute_url = urljoin(f"{api_base.rstrip('/')}/", unescape(login_url))
+        api = urlsplit(api_base)
+        login = urlsplit(absolute_url)
+        if (
+            api.scheme.lower() not in {"http", "https"}
+            or login.scheme.lower() not in {"http", "https"}
+            or not login.hostname
+            or login.username is not None
+            or login.password is not None
+            or login.fragment
+            or _url_origin(api) != _url_origin(login)
+        ):
+            raise ValueError
+        # Accessing .port above/below also rejects malformed port syntax.
+        _ = login.port
+    except (UnicodeError, ValueError):
+        raise ApiError("研究平台返回了无效的登录地址") from None
+    return absolute_url
+
+
+def _url_origin(parsed: Any) -> tuple[str, str, int | None]:
+    scheme = parsed.scheme.lower()
+    hostname = (parsed.hostname or "").lower()
+    port = parsed.port
+    if port is None:
+        port = 443 if scheme == "https" else 80 if scheme == "http" else None
+    return scheme, hostname, port
+
+
+def _parse_base_path(html: str) -> str:
+    parser = _BaseUrlParser()
+    try:
+        parser.feed(html)
+    except (TypeError, ValueError):
+        raise NotAuthenticatedError("无法建立研究平台登录会话") from None
+    if len(parser.values) != 1:
+        raise NotAuthenticatedError("无法建立研究平台登录会话")
+
+    value = unescape(parser.values[0])
+    try:
+        parsed = urlsplit(value)
+        match = re.fullmatch(r"/user/([^/]+)/", parsed.path)
+        if parsed.scheme or parsed.netloc or parsed.query or parsed.fragment or match is None:
+            raise ValueError
+        user_segment = match.group(1)
+        if re.search(r"%(?![0-9a-fA-F]{2})", user_segment):
+            raise ValueError
+        decoded_user = unquote(user_segment, errors="strict")
+        if decoded_user in {"", ".", ".."} or any(character in decoded_user for character in ("/", "\\", "\x00")):
+            raise ValueError
+    except (UnicodeError, ValueError):
+        raise ApiError("研究平台返回了无效的用户路径") from None
+    return parsed.path
+
+
+def _get_contents(
+    client: ApiClient,
+    base_path: str,
+    path: str,
+    *,
+    include_content: bool,
+) -> dict[str, Any]:
+    endpoint = _contents_endpoint(base_path, path)
+    payload = client.get(endpoint, params={"content": "1" if include_content else "0"})
+    if not isinstance(payload, dict):
+        raise ApiError("研究平台返回了无效的 Contents 响应")
+    return payload
+
+
+def _contents_endpoint(base_path: str, path: str) -> str:
+    endpoint = f"{base_path}api/contents"
+    if path:
+        endpoint = f"{endpoint}/{quote(path, safe='/')}"
+    return endpoint
+
+
+def _normalize_write_path(path: str) -> str:
+    normalized_path = normalize_research_path(path)
+    if not normalized_path:
+        raise UsageError("研究平台写操作不能以根目录为目标")
+    return normalized_path
+
+
+def _validate_save_payload(content: Any, *, item_type: str, content_format: str) -> None:
+    if item_type == "notebook":
+        if content_format != "json" or not isinstance(content, dict):
+            raise ApiError("Notebook 内容必须是 JSON 对象")
+        try:
+            json.dumps(content, allow_nan=False)
+        except (OverflowError, TypeError, ValueError):
+            raise ApiError("Notebook 内容不是可序列化的 JSON 对象") from None
+        return
+    if item_type == "file":
+        if content_format not in {"text", "base64"} or not isinstance(content, str):
+            raise ApiError("文件内容必须是 text 或 base64 字符串")
+        return
+    raise ApiError("研究平台只支持保存 file 或 notebook")
+
+
+def _prepare_research_write(client: ApiClient, target_path: str) -> tuple[str, str]:
+    base_path = _bootstrap_research(client)
+    client.get(f"{base_path}api")
+    xsrf_cookie = client.get_cookie("_xsrf", _contents_endpoint(base_path, target_path))
+    if not xsrf_cookie:
+        raise ApiError("研究平台未提供写操作所需的 XSRF 令牌")
+    xsrf_token = _decode_xsrf_cookie(xsrf_cookie)
+    return base_path, xsrf_token
+
+
+def _decode_xsrf_cookie(value: str) -> str:
+    token = value
+    if len(token) >= 2 and token[0] == token[-1] and token[0] in {'"', "'"}:
+        token = token[1:-1]
+    try:
+        token = unquote(token, errors="strict")
+    except UnicodeError:
+        raise ApiError("研究平台返回了无效的 XSRF 令牌") from None
+    if len(token) >= 2 and token[0] == token[-1] and token[0] in {'"', "'"}:
+        token = token[1:-1]
+    if not token or any(ord(character) < 0x20 or ord(character) == 0x7F for character in token):
+        raise ApiError("研究平台返回了无效的 XSRF 令牌")
+    return token
+
+
+def _normalize_item(raw: Any, *, include_content: bool) -> dict[str, Any]:
+    if not isinstance(raw, dict) or not all(isinstance(raw.get(key), str) for key in ("name", "path", "type")):
+        raise ApiError("研究平台返回了无效的 Contents 项")
+    item = {field: raw.get(field) for field in _RESEARCH_ITEM_FIELDS}
+    if include_content:
+        item["content"] = raw.get("content")
+    return item
+
+
+__all__ = [
+    "create_research_directory",
+    "delete_research_item",
+    "get_research_item",
+    "list_research_items",
+    "move_research_item",
+    "normalize_research_path",
+    "save_research_item",
+]

--- a/jqcli/api/research_execution.py
+++ b/jqcli/api/research_execution.py
@@ -1,0 +1,857 @@
+from __future__ import annotations
+
+import builtins
+import copy
+import json
+import math
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from time import monotonic
+from typing import Any, Callable, Iterator
+from urllib.parse import quote, urlencode, urlsplit, urlunsplit
+
+from websockets.exceptions import ConnectionClosed, InvalidHandshake
+from websockets.sync.client import connect as websocket_connect
+
+from jqcli.errors import ApiError, JqcliError, NetworkError, TimeoutError, UsageError
+
+from .client import ApiClient
+from .research import (
+    _bootstrap_research,
+    _decode_xsrf_cookie,
+    _get_contents,
+    _normalize_item,
+    normalize_research_path,
+)
+
+
+_MAX_WEBSOCKET_MESSAGE_SIZE = 16 * 1024 * 1024
+_MAX_EXECUTION_MESSAGE_COUNT = 10_000
+_MAX_EXECUTION_TOTAL_BYTES = 64 * 1024 * 1024
+_WebSocketConnector = Callable[..., Any]
+_EventHandler = Callable[[dict[str, Any]], None]
+
+
+def list_research_kernelspecs(client: ApiClient) -> dict[str, Any]:
+    """List sanitized kernel specifications exposed by the research server."""
+    base_path = _bootstrap_research(client)
+    payload = client.get(f"{base_path}api/kernelspecs")
+    return _normalize_kernelspecs(payload)
+
+
+def list_research_kernels(client: ApiClient) -> dict[str, Any]:
+    """List currently running research kernels without connecting to them."""
+    base_path = _bootstrap_research(client)
+    return _kernel_collection(client.get(f"{base_path}api/kernels"))
+
+
+def list_research_sessions(client: ApiClient) -> dict[str, Any]:
+    """List current research sessions without attaching to their kernels."""
+    base_path = _bootstrap_research(client)
+    return _session_collection(client.get(f"{base_path}api/sessions"))
+
+
+def execute_research_code(
+    client: ApiClient,
+    code: str,
+    *,
+    kernel_name: str | None = None,
+    execution_timeout: float = 120,
+    on_event: _EventHandler | None = None,
+    _websocket_connect: _WebSocketConnector | None = None,
+) -> dict[str, Any]:
+    """Execute code in a newly-created, isolated session/kernel and clean it up.
+
+    The returned object intentionally omits kernel, session, message, and SSO
+    identifiers.  ``on_event`` receives only normalized output/status events.
+    """
+    if not isinstance(code, str):
+        raise UsageError("研究平台执行代码必须是字符串")
+    if not code.strip():
+        raise UsageError("研究平台执行代码不能为空")
+    normalized_kernel_name = _normalize_kernel_name(kernel_name)
+    normalized_timeout = _normalize_timeout(execution_timeout)
+
+    with _temporary_runtime(
+        client,
+        kernel_name=normalized_kernel_name,
+        session_path=_synthetic_session_path(prefix="exec"),
+    ) as runtime:
+        deadline = monotonic() + normalized_timeout
+        socket = _open_kernel_socket(
+            client,
+            runtime["base_path"],
+            runtime["kernel_id"],
+            runtime["client_session_id"],
+            deadline,
+            connector=_websocket_connect,
+        )
+        try:
+            return _execute_on_socket(
+                socket,
+                code,
+                runtime["client_session_id"],
+                deadline,
+                on_event=on_event,
+            )
+        finally:
+            _close_socket(socket)
+
+
+def run_research_notebook(
+    client: ApiClient,
+    path: str,
+    *,
+    cell_indexes: list[int] | None = None,
+    kernel_name: str | None = None,
+    execution_timeout: float = 300,
+    on_event: _EventHandler | None = None,
+    _websocket_connect: _WebSocketConnector | None = None,
+) -> dict[str, Any]:
+    """Run all code cells in one new temporary session.
+
+    The notebook is read explicitly and never written back by this API.
+    """
+    normalized_path = normalize_research_path(path)
+    if not normalized_path:
+        raise UsageError("运行 Notebook 时必须指定研究平台文件路径")
+    normalized_kernel_name = _normalize_kernel_name(kernel_name)
+    normalized_timeout = _normalize_timeout(execution_timeout)
+
+    base_path = _bootstrap_research(client)
+    raw_item = _get_contents(client, base_path, normalized_path, include_content=True)
+    item = _normalize_item(raw_item, include_content=True)
+    notebook = _validated_notebook_copy(item)
+    if normalized_kernel_name is None:
+        normalized_kernel_name = _notebook_kernel_name(notebook)
+    all_code_cells = [
+        (index, cell)
+        for index, cell in enumerate(notebook["cells"])
+        if cell.get("cell_type") == "code"
+    ]
+    code_cells = _select_code_cells(notebook["cells"], all_code_cells, cell_indexes)
+    cell_results: list[dict[str, Any]] = []
+    run_status = "ok"
+
+    if code_cells:
+        synthetic_path = _synthetic_session_path(normalized_path)
+        with _temporary_runtime(
+            client,
+            kernel_name=normalized_kernel_name,
+            session_path=synthetic_path,
+            base_path=base_path,
+        ) as runtime:
+            deadline = monotonic() + normalized_timeout
+            socket = _open_kernel_socket(
+                client,
+                runtime["base_path"],
+                runtime["kernel_id"],
+                runtime["client_session_id"],
+                deadline,
+                connector=_websocket_connect,
+            )
+            try:
+                message_budget = {"count": 0, "bytes": 0}
+                for cell_index, cell in code_cells:
+                    source = _cell_source(cell, cell_index)
+
+                    def cell_event(event: dict[str, Any], *, _index: int = cell_index) -> None:
+                        if on_event is not None:
+                            on_event({"cell_index": _index, **event})
+
+                    result = _execute_on_socket(
+                        socket,
+                        source,
+                        runtime["client_session_id"],
+                        deadline,
+                        on_event=cell_event if on_event is not None else None,
+                        message_budget=message_budget,
+                    )
+                    cell["execution_count"] = result["execution_count"]
+                    cell["outputs"] = copy.deepcopy(result["outputs"])
+                    cell_results.append({"cell_index": cell_index, **result})
+                    if result["status"] != "ok":
+                        run_status = result["status"]
+                        break
+            finally:
+                _close_socket(socket)
+
+    return {
+        "status": run_status,
+        "path": normalized_path,
+        "total_code_cells": len(all_code_cells),
+        "selected_code_cells": len(code_cells),
+        "executed_cells": len(cell_results),
+        "cells": cell_results,
+        "saved": False,
+    }
+
+
+@contextmanager
+def _temporary_runtime(
+    client: ApiClient,
+    *,
+    kernel_name: str | None,
+    session_path: str,
+    base_path: str | None = None,
+) -> Iterator[dict[str, str]]:
+    if base_path is None:
+        base_path = _bootstrap_research(client)
+    client.get(f"{base_path}api")
+
+    existing_kernels = _kernel_collection(client.get(f"{base_path}api/kernels"))
+    existing_kernel_ids = {item["id"] for item in existing_kernels["items"]}
+    existing_sessions = _session_collection(client.get(f"{base_path}api/sessions"))
+    existing_session_ids = {item["id"] for item in existing_sessions["items"]}
+    if any(item["path"] == session_path for item in existing_sessions["items"]):
+        raise ApiError("研究平台临时会话路径发生冲突，请重试")
+
+    cleanup: tuple[str, str] | None = None
+    primary_error: BaseException | None = None
+    try:
+        try:
+            raw = _create_session(client, base_path, session_path, kernel_name)
+            candidate_session_id = _candidate_identifier(raw, "id")
+            raw_kernel = raw.get("kernel") if isinstance(raw, dict) else None
+            candidate_kernel_id = _candidate_identifier(raw_kernel, "id")
+            if (
+                candidate_session_id in existing_session_ids
+                or candidate_kernel_id in existing_kernel_ids
+            ):
+                # Deleting a session that unexpectedly reused an existing
+                # kernel could shut down a user-owned interactive kernel.
+                raise ApiError("研究平台没有创建隔离的临时会话和内核")
+            cleanup = ("session", candidate_session_id)
+            session = _normalize_session(raw)
+            if session["path"] != session_path:
+                raise ApiError("研究平台临时会话路径与请求不一致")
+            resource_id = session["kernel"]["id"]
+        except JqcliError:
+            if cleanup is None:
+                cleanup = _recover_created_session(
+                    client,
+                    base_path,
+                    session_path,
+                    existing_session_ids,
+                    existing_kernel_ids,
+                )
+            raise
+
+        yield {
+            "base_path": base_path,
+            "kernel_id": resource_id,
+            "client_session_id": uuid.uuid4().hex,
+        }
+    except BaseException as exc:
+        primary_error = exc
+        raise
+    finally:
+        if cleanup is not None:
+            try:
+                _delete_temporary_resource(client, base_path, *cleanup)
+            except JqcliError:
+                if primary_error is None:
+                    raise
+                if isinstance(primary_error, JqcliError):
+                    primary_error.details = {**primary_error.details, "cleanup_failed": True}
+
+
+def _create_session(
+    client: ApiClient,
+    base_path: str,
+    notebook_path: str,
+    kernel_name: str | None,
+) -> Any:
+    endpoint = f"{base_path}api/sessions"
+    kernel: dict[str, str] = {}
+    if kernel_name is not None:
+        kernel["name"] = kernel_name
+    body = {
+        "path": notebook_path,
+        # Match Notebook 5.4.1's own Session._get_model payload.  The full
+        # synthetic path is the ownership key; name remains intentionally empty.
+        "name": "",
+        "type": "notebook",
+        "kernel": kernel,
+    }
+    return _post_created_json(client, endpoint, body)
+
+
+def _post_created_json(client: ApiClient, endpoint: str, body: dict[str, Any]) -> Any:
+    response = client.request_response(
+        "POST",
+        endpoint,
+        json=body,
+        headers={"X-XSRFToken": _xsrf_token_for(client, endpoint)},
+    )
+    if response.status_code != 201:
+        raise ApiError(f"研究平台创建临时执行资源返回了意外状态（HTTP {response.status_code}）")
+    try:
+        return response.json()
+    except ValueError:
+        raise ApiError("研究平台返回了无效的临时执行资源 JSON") from None
+
+
+def _delete_temporary_resource(
+    client: ApiClient,
+    base_path: str,
+    resource_type: str,
+    resource_id: str,
+) -> None:
+    collection = "sessions" if resource_type == "session" else "kernels"
+    endpoint = f"{base_path}api/{collection}/{quote(resource_id, safe='')}"
+    response = client.request_response(
+        "DELETE",
+        endpoint,
+        headers={"X-XSRFToken": _xsrf_token_for(client, endpoint)},
+    )
+    if response.status_code != 204:
+        raise ApiError(f"研究平台清理临时执行资源返回了意外状态（HTTP {response.status_code}）")
+
+
+def _recover_created_session(
+    client: ApiClient,
+    base_path: str,
+    synthetic_path: str,
+    existing_session_ids: set[str],
+    existing_kernel_ids: set[str],
+) -> tuple[str, str] | None:
+    """Find a lost POST result only by its unguessable synthetic path."""
+    try:
+        sessions = _session_collection(client.get(f"{base_path}api/sessions"))["items"]
+    except JqcliError:
+        return None
+    matches = [session for session in sessions if session["path"] == synthetic_path]
+    if len(matches) != 1:
+        return None
+    session = matches[0]
+    if session["id"] in existing_session_ids or session["kernel"]["id"] in existing_kernel_ids:
+        return None
+    return "session", session["id"]
+
+
+def _xsrf_token_for(client: ApiClient, endpoint: str) -> str:
+    cookie = client.get_cookie("_xsrf", endpoint)
+    if not cookie:
+        raise ApiError("研究平台未提供远端执行所需的 XSRF 令牌")
+    return _decode_xsrf_cookie(cookie)
+
+
+def _open_kernel_socket(
+    client: ApiClient,
+    base_path: str,
+    kernel_id: str,
+    client_session_id: str,
+    deadline: float,
+    *,
+    connector: _WebSocketConnector | None,
+) -> Any:
+    remaining = _remaining_time(deadline)
+    ws_url, origin, http_endpoint = _kernel_channel_urls(
+        client.api_base,
+        base_path,
+        kernel_id,
+        client_session_id,
+    )
+    cookie_header = client.get_cookie_header(http_endpoint)
+    additional_headers = {"Cookie": cookie_header} if cookie_header else None
+    connect = connector or websocket_connect
+    try:
+        return connect(
+            ws_url,
+            origin=origin,
+            additional_headers=additional_headers,
+            proxy=None,
+            open_timeout=remaining,
+            close_timeout=min(5.0, remaining),
+            max_size=_MAX_WEBSOCKET_MESSAGE_SIZE,
+        )
+    except builtins.TimeoutError:
+        raise TimeoutError("研究平台交互连接建立超时") from None
+    except (InvalidHandshake, OSError):
+        raise NetworkError("无法建立研究平台交互连接") from None
+
+
+def _kernel_channel_urls(
+    api_base: str,
+    base_path: str,
+    kernel_id: str,
+    client_session_id: str,
+) -> tuple[str, str, str]:
+    try:
+        parsed = urlsplit(api_base)
+        if (
+            parsed.scheme.lower() not in {"http", "https"}
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.fragment
+        ):
+            raise ValueError
+        _ = parsed.port
+    except (UnicodeError, ValueError):
+        raise ApiError("API 基地址不能用于研究平台交互连接") from None
+
+    endpoint = f"{base_path}api/kernels/{quote(kernel_id, safe='')}/channels"
+    query = urlencode({"session_id": client_session_id})
+    ws_scheme = "wss" if parsed.scheme.lower() == "https" else "ws"
+    ws_url = urlunsplit((ws_scheme, parsed.netloc, endpoint, query, ""))
+    origin = urlunsplit((parsed.scheme.lower(), parsed.netloc, "", "", ""))
+    http_endpoint = urlunsplit((parsed.scheme.lower(), parsed.netloc, endpoint, query, ""))
+    return ws_url, origin, http_endpoint
+
+
+def _execute_on_socket(
+    socket: Any,
+    code: str,
+    client_session_id: str,
+    deadline: float,
+    *,
+    on_event: _EventHandler | None,
+    message_budget: dict[str, int] | None = None,
+) -> dict[str, Any]:
+    message_id = uuid.uuid4().hex
+    request = {
+        "header": {
+            "msg_id": message_id,
+            "username": "jqcli",
+            "session": client_session_id,
+            "date": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "msg_type": "execute_request",
+            "version": "5.2",
+        },
+        "parent_header": {},
+        "metadata": {},
+        "content": {
+            "code": code,
+            "silent": False,
+            "store_history": True,
+            "user_expressions": {},
+            "allow_stdin": False,
+            "stop_on_error": True,
+        },
+        "channel": "shell",
+        "buffers": [],
+    }
+    try:
+        socket.send(json.dumps(request, ensure_ascii=False, separators=(",", ":")))
+    except (ConnectionClosed, OSError):
+        raise NetworkError("研究平台交互连接在发送请求时关闭") from None
+
+    outputs: list[dict[str, Any]] = []
+    execution_count: int | None = None
+    reply_status: str | None = None
+    shell_reply_received = False
+    idle_received = False
+    clear_on_next_output = False
+    if message_budget is None:
+        message_budget = {"count": 0, "bytes": 0}
+
+    while not (shell_reply_received and idle_received):
+        remaining = _remaining_time(deadline)
+        try:
+            raw = socket.recv(timeout=remaining)
+        except builtins.TimeoutError:
+            raise TimeoutError("研究平台代码执行超时") from None
+        except (ConnectionClosed, OSError):
+            raise NetworkError("研究平台交互连接意外关闭") from None
+
+        frame_size = _kernel_frame_size(raw)
+        message_budget["count"] += 1
+        message_budget["bytes"] += frame_size
+        if (
+            frame_size > _MAX_WEBSOCKET_MESSAGE_SIZE
+            or message_budget["count"] > _MAX_EXECUTION_MESSAGE_COUNT
+            or message_budget["bytes"] > _MAX_EXECUTION_TOTAL_BYTES
+        ):
+            raise ApiError("研究平台内核消息超过安全处理上限")
+        message = _decode_kernel_message(raw)
+        parent_header = message.get("parent_header")
+        if not isinstance(parent_header, dict) or parent_header.get("msg_id") != message_id:
+            continue
+        header = message.get("header")
+        if not isinstance(header, dict) or not isinstance(header.get("msg_type"), str):
+            raise ApiError("研究平台返回了无效的内核消息头")
+        message_type = header["msg_type"]
+        channel = message.get("channel")
+        content = message.get("content")
+        if not isinstance(channel, str) or not isinstance(content, dict):
+            raise ApiError("研究平台返回了无效的内核消息")
+
+        if message_type == "input_request":
+            raise ApiError("远端代码请求交互输入；当前执行禁用了 stdin")
+
+        if channel == "shell" and message_type == "execute_reply":
+            reply_status = content.get("status")
+            if reply_status not in {"ok", "error", "abort"}:
+                raise ApiError("研究平台返回了无效的执行结果状态")
+            execution_count = _optional_execution_count(content.get("execution_count"))
+            shell_reply_received = True
+            _emit_event(
+                on_event,
+                {
+                    "event": "execute_reply",
+                    "status": "aborted" if reply_status == "abort" else reply_status,
+                    "execution_count": execution_count,
+                },
+            )
+            continue
+
+        if channel != "iopub":
+            continue
+        if message_type == "status":
+            state = content.get("execution_state")
+            if not isinstance(state, str):
+                raise ApiError("研究平台返回了无效的内核状态")
+            idle_received = state == "idle" or idle_received
+            _emit_event(on_event, {"event": "status", "state": state})
+            continue
+        if message_type == "execute_input":
+            execution_count = _optional_execution_count(content.get("execution_count"))
+            continue
+        if message_type == "clear_output":
+            wait = content.get("wait", False)
+            if not isinstance(wait, bool):
+                raise ApiError("研究平台返回了无效的 clear_output 消息")
+            if wait:
+                clear_on_next_output = True
+            else:
+                outputs.clear()
+                clear_on_next_output = False
+            _emit_event(on_event, {"event": "clear_output", "wait": wait})
+            continue
+        if message_type in {"stream", "display_data", "execute_result", "update_display_data", "error"}:
+            output = _normalize_output(message_type, content)
+            if clear_on_next_output:
+                outputs.clear()
+                clear_on_next_output = False
+            outputs.append(output)
+            _emit_event(on_event, {"event": "output", "output": copy.deepcopy(output)})
+
+    status = "aborted" if reply_status == "abort" else reply_status
+    if any(output["output_type"] == "error" for output in outputs):
+        status = "error"
+    return {
+        "status": status,
+        "execution_count": execution_count,
+        "outputs": outputs,
+    }
+
+
+def _decode_kernel_message(raw: Any) -> dict[str, Any]:
+    if isinstance(raw, str):
+        encoded = raw
+    elif isinstance(raw, (bytes, bytearray, memoryview)):
+        encoded = _decode_binary_kernel_frame(bytes(raw))
+    else:
+        raise ApiError("研究平台返回了不支持的内核消息类型")
+    try:
+        payload = json.loads(encoded, parse_constant=_reject_json_constant)
+    except (RecursionError, TypeError, UnicodeError, ValueError):
+        raise ApiError("研究平台返回了无效的内核消息 JSON") from None
+    if not isinstance(payload, dict):
+        raise ApiError("研究平台返回了无效的内核消息")
+    return payload
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _decode_binary_kernel_frame(raw: bytes) -> str:
+    # Notebook 5.4.1 serialize.js stores a big-endian uint32 buffer count,
+    # followed by that many big-endian offsets.  Buffer zero is UTF-8 JSON.
+    if len(raw) < 8:
+        raise ApiError("研究平台返回了无效的二进制内核消息")
+    buffer_count = int.from_bytes(raw[0:4], "big")
+    if buffer_count < 1 or buffer_count > (len(raw) - 4) // 4:
+        raise ApiError("研究平台返回了无效的二进制内核消息")
+    header_size = 4 * (buffer_count + 1)
+    offsets = [
+        int.from_bytes(raw[4 * index : 4 * (index + 1)], "big")
+        for index in range(1, buffer_count + 1)
+    ]
+    if (
+        offsets[0] != header_size
+        or any(offset > len(raw) for offset in offsets)
+        or any(left > right for left, right in zip(offsets, offsets[1:]))
+    ):
+        raise ApiError("研究平台返回了无效的二进制内核消息")
+    json_end = offsets[1] if len(offsets) > 1 else len(raw)
+    try:
+        return raw[offsets[0] : json_end].decode("utf-8", errors="strict")
+    except UnicodeError:
+        raise ApiError("研究平台返回了无效的二进制内核消息") from None
+
+
+def _kernel_frame_size(raw: Any) -> int:
+    if isinstance(raw, str):
+        return len(raw.encode("utf-8"))
+    if isinstance(raw, (bytes, bytearray, memoryview)):
+        return len(raw)
+    raise ApiError("研究平台返回了不支持的内核消息类型")
+
+
+def _normalize_output(message_type: str, content: dict[str, Any]) -> dict[str, Any]:
+    if message_type == "stream":
+        name = content.get("name")
+        text = content.get("text")
+        if name not in {"stdout", "stderr"} or not isinstance(text, str):
+            raise ApiError("研究平台返回了无效的 stream 输出")
+        return {"output_type": "stream", "name": name, "text": text}
+    if message_type in {"display_data", "update_display_data"}:
+        data, metadata = _display_payload(content)
+        return {"output_type": "display_data", "data": data, "metadata": metadata}
+    if message_type == "execute_result":
+        data, metadata = _display_payload(content)
+        return {
+            "output_type": "execute_result",
+            "execution_count": _optional_execution_count(content.get("execution_count")),
+            "data": data,
+            "metadata": metadata,
+        }
+    if message_type == "error":
+        ename = content.get("ename")
+        evalue = content.get("evalue")
+        traceback = content.get("traceback")
+        if (
+            not isinstance(ename, str)
+            or not isinstance(evalue, str)
+            or not isinstance(traceback, list)
+            or not all(isinstance(line, str) for line in traceback)
+        ):
+            raise ApiError("研究平台返回了无效的 error 输出")
+        return {
+            "output_type": "error",
+            "ename": ename,
+            "evalue": evalue,
+            "traceback": traceback,
+        }
+    raise ApiError("研究平台返回了不支持的输出类型")
+
+
+def _display_payload(content: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    data = content.get("data")
+    metadata = content.get("metadata")
+    if not isinstance(data, dict) or not isinstance(metadata, dict):
+        raise ApiError("研究平台返回了无效的富媒体输出")
+    return copy.deepcopy(data), copy.deepcopy(metadata)
+
+
+def _normalize_kernelspecs(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, dict) or not isinstance(raw.get("default"), str):
+        raise ApiError("研究平台返回了无效的 KernelSpec 响应")
+    specs = raw.get("kernelspecs")
+    if not isinstance(specs, dict):
+        raise ApiError("研究平台返回了无效的 KernelSpec 响应")
+    items: list[dict[str, Any]] = []
+    for name, value in specs.items():
+        if not isinstance(name, str) or not isinstance(value, dict) or not isinstance(value.get("spec"), dict):
+            raise ApiError("研究平台返回了无效的 KernelSpec 项")
+        spec = value["spec"]
+        display_name = spec.get("display_name")
+        language = spec.get("language")
+        interrupt_mode = spec.get("interrupt_mode")
+        if (
+            not isinstance(display_name, str)
+            or not isinstance(language, str)
+            or (interrupt_mode is not None and not isinstance(interrupt_mode, str))
+        ):
+            raise ApiError("研究平台返回了无效的 KernelSpec 项")
+        items.append(
+            {
+                "name": name,
+                "display_name": display_name,
+                "language": language,
+                "interrupt_mode": interrupt_mode,
+            }
+        )
+    items.sort(key=lambda item: item["name"])
+    if raw["default"] not in specs:
+        raise ApiError("研究平台默认 KernelSpec 不存在")
+    return {"default": raw["default"], "items": items, "total": len(items)}
+
+
+def _kernel_collection(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, list):
+        raise ApiError("研究平台返回了无效的内核列表")
+    items = [_normalize_kernel(item) for item in raw]
+    return {"items": items, "total": len(items)}
+
+
+def _session_collection(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, list):
+        raise ApiError("研究平台返回了无效的会话列表")
+    items = [_normalize_session(item) for item in raw]
+    return {"items": items, "total": len(items)}
+
+
+def _normalize_kernel(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise ApiError("研究平台返回了无效的内核项")
+    identifier = _candidate_identifier(raw, "id")
+    name = raw.get("name")
+    last_activity = raw.get("last_activity")
+    execution_state = raw.get("execution_state")
+    connections = raw.get("connections")
+    if (
+        not isinstance(name, str)
+        or (last_activity is not None and not isinstance(last_activity, str))
+        or (execution_state is not None and not isinstance(execution_state, str))
+        or (connections is not None and (not isinstance(connections, int) or isinstance(connections, bool)))
+    ):
+        raise ApiError("研究平台返回了无效的内核项")
+    return {
+        "id": identifier,
+        "name": name,
+        "last_activity": last_activity,
+        "execution_state": execution_state,
+        "connections": connections,
+    }
+
+
+def _normalize_session(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise ApiError("研究平台返回了无效的会话项")
+    identifier = _candidate_identifier(raw, "id")
+    path = raw.get("path")
+    name = raw.get("name")
+    session_type = raw.get("type")
+    if not all(isinstance(value, str) for value in (path, name, session_type)):
+        raise ApiError("研究平台返回了无效的会话项")
+    kernel = _normalize_kernel(raw.get("kernel"))
+    return {"id": identifier, "path": path, "name": name, "type": session_type, "kernel": kernel}
+
+
+def _candidate_identifier(raw: Any, field: str) -> str:
+    value = raw.get(field) if isinstance(raw, dict) else None
+    if (
+        not isinstance(value, str)
+        or not value
+        or any(ord(character) < 0x20 or ord(character) == 0x7F for character in value)
+    ):
+        raise ApiError("研究平台返回了无效的临时资源标识")
+    return value
+
+
+def _validated_notebook_copy(item: dict[str, Any]) -> dict[str, Any]:
+    if item.get("type") != "notebook" or not isinstance(item.get("content"), dict):
+        raise ApiError("指定的研究平台文件不是有效 Notebook")
+    notebook = copy.deepcopy(item["content"])
+    cells = notebook.get("cells")
+    if not isinstance(cells, list) or not all(isinstance(cell, dict) for cell in cells):
+        raise ApiError("研究平台 Notebook 包含无效的 cells")
+    return notebook
+
+
+def _cell_source(cell: dict[str, Any], cell_index: int) -> str:
+    source = cell.get("source", "")
+    if isinstance(source, str):
+        return source
+    if isinstance(source, list) and all(isinstance(part, str) for part in source):
+        return "".join(source)
+    raise ApiError("研究平台 Notebook 包含无效的代码单元", details={"cell_index": cell_index})
+
+
+def _notebook_kernel_name(notebook: dict[str, Any]) -> str | None:
+    metadata = notebook.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    kernelspec = metadata.get("kernelspec")
+    if not isinstance(kernelspec, dict):
+        return None
+    name = kernelspec.get("name")
+    if not isinstance(name, str) or not name:
+        return None
+    try:
+        return _normalize_kernel_name(name)
+    except UsageError:
+        raise ApiError("研究平台 Notebook 包含无效的 kernelspec 名称") from None
+
+
+def _select_code_cells(
+    notebook_cells: list[dict[str, Any]],
+    all_code_cells: list[tuple[int, dict[str, Any]]],
+    selected: list[int] | None,
+) -> list[tuple[int, dict[str, Any]]]:
+    if selected is None:
+        return all_code_cells
+    if not isinstance(selected, list) or any(
+        isinstance(index, bool) or not isinstance(index, int) or index < 0 for index in selected
+    ):
+        raise UsageError("Notebook 单元索引必须是非负整数")
+    if len(set(selected)) != len(selected):
+        raise UsageError("Notebook 单元索引不能重复")
+    selected_indexes = set(selected)
+    for index in selected:
+        if index >= len(notebook_cells):
+            raise UsageError(f"Notebook 单元索引越界：{index}")
+        if notebook_cells[index].get("cell_type") != "code":
+            raise UsageError(f"Notebook 单元不是代码单元：{index}")
+    # Execute in notebook order so dependencies remain deterministic even when
+    # repeated --cell options are provided out of order.
+    return [(index, cell) for index, cell in all_code_cells if index in selected_indexes]
+
+
+def _synthetic_session_path(notebook_path: str = "", *, prefix: str = "run") -> str:
+    directory, separator, _ = notebook_path.rpartition("/")
+    name = f"__jqcli_{prefix}_{uuid.uuid4().hex}.ipynb"
+    return f"{directory}/{name}" if separator else name
+
+
+def _normalize_kernel_name(value: str | None) -> str | None:
+    if value is None:
+        return None
+    if (
+        not isinstance(value, str)
+        or not value
+        or any(ord(character) < 0x20 or ord(character) == 0x7F for character in value)
+    ):
+        raise UsageError("研究平台内核名称无效")
+    return value
+
+
+def _normalize_timeout(value: float) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise UsageError("研究平台执行超时必须是正数")
+    timeout = float(value)
+    if not math.isfinite(timeout) or timeout <= 0:
+        raise UsageError("研究平台执行超时必须是正数")
+    return timeout
+
+
+def _remaining_time(deadline: float) -> float:
+    remaining = deadline - monotonic()
+    if remaining <= 0:
+        raise TimeoutError("研究平台代码执行超时")
+    return remaining
+
+
+def _optional_execution_count(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ApiError("研究平台返回了无效的 execution_count")
+    return value
+
+
+def _emit_event(handler: _EventHandler | None, event: dict[str, Any]) -> None:
+    if handler is not None:
+        handler(event)
+
+
+def _close_socket(socket: Any) -> None:
+    try:
+        socket.close()
+    except (ConnectionClosed, OSError):
+        return
+
+
+__all__ = [
+    "execute_research_code",
+    "list_research_kernels",
+    "list_research_kernelspecs",
+    "list_research_sessions",
+    "run_research_notebook",
+]

--- a/jqcli/cli.py
+++ b/jqcli/cli.py
@@ -63,7 +63,7 @@ def main(
     debug: bool,
     timeout: float | None,
 ) -> None:
-    """聚宽策略与回测管理命令行工具。"""
+    """聚宽策略、回测与研究工作区管理命令行工具。"""
     load_env_file(env_file)
     config = load_config(config_path)
     resolved_token, resolved_cookie = resolve_credentials(config, token=token, cookie=cookie)
@@ -83,12 +83,14 @@ def main(
 from .commands.auth import auth_group
 from .commands.backtest import backtest_group
 from .commands.community import community_group
+from .commands.research import research_group
 from .commands.strategy import strategy_group
 from .commands.web import web_group
 
 main.add_command(auth_group, "auth")
 main.add_command(backtest_group, "backtest")
 main.add_command(community_group, "community")
+main.add_command(research_group, "research")
 main.add_command(strategy_group, "strategy")
 main.add_command(web_group, "web")
 

--- a/jqcli/commands/research.py
+++ b/jqcli/commands/research.py
@@ -1,0 +1,655 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import math
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING, Any, Callable
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from jqcli.api.client import ApiClient
+from jqcli.api.research import (
+    create_research_directory,
+    delete_research_item,
+    get_research_item,
+    list_research_items,
+    move_research_item,
+    normalize_research_path,
+    save_research_item,
+)
+from jqcli.api.research_execution import (
+    execute_research_code,
+    list_research_kernels,
+    list_research_kernelspecs,
+    list_research_sessions,
+    run_research_notebook,
+)
+from jqcli.errors import (
+    ConfirmationRequiredError,
+    FileError,
+    NotAuthenticatedError,
+    NotFoundError,
+    UsageError,
+)
+from jqcli.output import write_json, write_json_line
+
+
+if TYPE_CHECKING:
+    from jqcli.cli import AppContext
+
+
+MAX_UPLOAD_BYTES = 25 * 1024 * 1024
+DEFAULT_EXECUTION_TIMEOUT = 120.0
+
+
+@click.group(name="research")
+def research_group() -> None:
+    """研究平台文件与 Notebook 管理。"""
+
+
+def make_client(app: AppContext) -> ApiClient:
+    if not app.cookie:
+        raise NotAuthenticatedError("研究平台需要有效 cookie；请执行 auth login 或提供 JQCLI_COOKIE")
+    return ApiClient(app.api_base, cookie=app.cookie, timeout=app.timeout)
+
+
+def close_client(client: object) -> None:
+    close = getattr(client, "close", None)
+    if callable(close):
+        close()
+
+
+def render_research_table(items: list[dict[str, Any]]) -> None:
+    table = Table()
+    for name in ("名称", "类型", "大小", "最近修改", "可写"):
+        table.add_column(name)
+    for item in items:
+        writable = item.get("writable")
+        table.add_row(
+            str(item.get("name", "")),
+            str(item.get("type", "")),
+            "" if item.get("size") is None else str(item["size"]),
+            str(item.get("last_modified", "")),
+            "" if writable is None else ("是" if bool(writable) else "否"),
+        )
+    Console().print(table)
+
+
+def render_kernelspecs_table(payload: dict[str, Any]) -> None:
+    default_name = str(payload.get("default") or "")
+    table = Table()
+    for name in ("名称", "显示名称", "语言", "中断模式", "默认"):
+        table.add_column(name)
+    for item in payload.get("items", []):
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name") or "")
+        table.add_row(
+            name,
+            str(item.get("display_name") or ""),
+            str(item.get("language") or ""),
+            str(item.get("interrupt_mode") or ""),
+            "是" if name == default_name else "",
+        )
+    Console().print(table)
+
+
+def render_kernels_table(payload: dict[str, Any]) -> None:
+    table = Table()
+    for name in ("ID", "名称", "状态", "连接数", "最近活动"):
+        table.add_column(name)
+    for item in payload.get("items", []):
+        if not isinstance(item, dict):
+            continue
+        table.add_row(
+            str(item.get("id") or ""),
+            str(item.get("name") or ""),
+            str(item.get("execution_state") or ""),
+            "" if item.get("connections") is None else str(item["connections"]),
+            str(item.get("last_activity") or ""),
+        )
+    Console().print(table)
+
+
+def render_sessions_table(payload: dict[str, Any]) -> None:
+    table = Table()
+    for name in ("ID", "路径", "类型", "内核", "状态"):
+        table.add_column(name)
+    for item in payload.get("items", []):
+        if not isinstance(item, dict):
+            continue
+        kernel = item.get("kernel") if isinstance(item.get("kernel"), dict) else {}
+        table.add_row(
+            str(item.get("id") or ""),
+            str(item.get("path") or ""),
+            str(item.get("type") or ""),
+            str(kernel.get("name") or ""),
+            str(kernel.get("execution_state") or ""),
+        )
+    Console().print(table)
+
+
+def render_research_item(payload: dict[str, Any], *, include_content: bool) -> None:
+    for label, key in (
+        ("路径", "path"),
+        ("名称", "name"),
+        ("类型", "type"),
+        ("格式", "format"),
+        ("MIME", "mimetype"),
+        ("大小", "size"),
+        ("最近修改", "last_modified"),
+        ("可写", "writable"),
+    ):
+        value = payload.get(key)
+        if value is not None:
+            click.echo(f"{label}: {value}")
+    if not include_content:
+        return
+    content = payload.get("content")
+    click.echo("内容:")
+    if payload.get("format") == "json" or not isinstance(content, str):
+        click.echo(json.dumps(content, ensure_ascii=False, indent=2))
+    else:
+        click.echo(content)
+
+
+def _safe_basename(payload: dict[str, Any], requested_path: str) -> str:
+    for raw_value in (payload.get("name"), payload.get("path"), requested_path):
+        value = str(raw_value or "").replace("\\", "/").rstrip("/")
+        if not value:
+            continue
+        name = PurePosixPath(value).name
+        if name not in {"", ".", ".."} and "\x00" not in name:
+            return name
+    raise FileError("无法从研究路径确定安全的本地文件名；请传入 --output")
+
+
+def _download_bytes(payload: dict[str, Any]) -> bytes:
+    if payload.get("type") == "directory":
+        raise UsageError("研究目录不能下载；请指定文件或 Notebook")
+    content = payload.get("content")
+    if content is None:
+        raise FileError("研究文件响应未包含内容")
+    content_format = str(payload.get("format") or ("json" if payload.get("type") == "notebook" else ""))
+    if content_format == "base64":
+        if not isinstance(content, str):
+            raise FileError("研究文件响应中的 base64 内容不是字符串")
+        try:
+            return base64.b64decode(content, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise FileError("研究文件响应包含无效 base64 内容") from exc
+    if content_format == "json":
+        if isinstance(content, str):
+            try:
+                content = json.loads(content)
+            except ValueError as exc:
+                raise FileError("研究文件响应包含无效 JSON 内容") from exc
+        try:
+            return (json.dumps(content, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
+        except (TypeError, ValueError) as exc:
+            raise FileError("研究文件响应中的 JSON 内容无法序列化") from exc
+    if content_format == "text":
+        if not isinstance(content, str):
+            raise FileError("研究文件响应中的文本内容不是字符串")
+        return content.encode("utf-8")
+    raise FileError(f"不支持下载研究文件格式：{content_format or 'unknown'}")
+
+
+def _confirm_write(app: AppContext, yes: bool, prompt: str) -> None:
+    if (app.non_interactive or app.json_output) and not yes:
+        raise ConfirmationRequiredError()
+    if not yes:
+        click.confirm(prompt, abort=True)
+
+
+def _confirm_execution(yes: bool) -> None:
+    if not yes:
+        raise ConfirmationRequiredError(
+            "远端执行代码可能产生账户侧副作用；必须显式传入 --yes"
+        )
+
+
+def _validate_execution_timeout(value: float) -> float:
+    if not math.isfinite(value) or value <= 0:
+        raise UsageError("--execution-timeout 必须大于 0")
+    return value
+
+
+def _validate_cells(cells: tuple[int, ...]) -> list[int] | None:
+    if any(cell < 0 for cell in cells):
+        raise UsageError("--cell 必须是非负整数")
+    if len(set(cells)) != len(cells):
+        raise UsageError("--cell 不能重复")
+    return list(cells) if cells else None
+
+
+def _read_execution_code(local_file: str | None, code_stdin: bool) -> str:
+    if bool(local_file) == bool(code_stdin):
+        raise UsageError("必须且只能指定 --file 或 --code-stdin 之一")
+    try:
+        if local_file is not None:
+            raw = Path(local_file).read_bytes()
+        else:
+            raw = click.get_binary_stream("stdin").read()
+    except OSError as exc:
+        source = local_file or "标准输入"
+        raise FileError(f"无法读取执行代码：{source}") from exc
+    try:
+        code = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        source = local_file or "标准输入"
+        raise FileError(f"执行代码必须是 UTF-8 文本：{source}") from exc
+    if not code.strip():
+        raise FileError("执行代码不能为空")
+    return code
+
+
+def _safe_terminal_text(value: object) -> str:
+    if isinstance(value, list):
+        value = "".join(str(part) for part in value)
+    text = str(value or "")
+    return "".join(
+        character
+        for character in text
+        if character in "\n\r\t" or (ord(character) >= 32 and not 127 <= ord(character) <= 159)
+    )
+
+
+def _execution_outputs(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    outputs = payload.get("outputs")
+    if isinstance(outputs, list):
+        return [output for output in outputs if isinstance(output, dict)]
+    return []
+
+
+def _render_output_summary(output: dict[str, Any]) -> None:
+    output_type = str(output.get("type") or output.get("output_type") or "")
+    if output_type == "stream":
+        name = _safe_terminal_text(output.get("name") or "stream")
+        text = _safe_terminal_text(output.get("text"))
+        click.echo(f"[{name}] {text}", nl=not text.endswith("\n"))
+        return
+    if output_type in {"display_data", "execute_result"}:
+        data = output.get("data") if isinstance(output.get("data"), dict) else {}
+        if "text/plain" in data:
+            click.echo(_safe_terminal_text(data["text/plain"]))
+        return
+    if output_type == "error":
+        name = _safe_terminal_text(output.get("ename") or "Error")
+        value = _safe_terminal_text(output.get("evalue"))
+        click.echo(f"错误: {name}{(': ' + value) if value else ''}")
+
+
+def render_execution_result(payload: dict[str, Any]) -> None:
+    status = _safe_terminal_text(payload.get("status") or "unknown")
+    click.echo(f"状态: {status}")
+    if payload.get("execution_count") is not None:
+        click.echo(f"执行序号: {payload['execution_count']}")
+    for output in _execution_outputs(payload):
+        _render_output_summary(output)
+
+    cells = payload.get("cells")
+    if not isinstance(cells, list):
+        return
+    for ordinal, cell in enumerate(cells):
+        if not isinstance(cell, dict):
+            continue
+        index = cell.get("cell_index", cell.get("index", ordinal))
+        click.echo(f"单元格 {index}:")
+        for output in _execution_outputs(cell):
+            _render_output_summary(output)
+
+
+def _stream_callback() -> Callable[[dict[str, Any]], None]:
+    def emit(event: dict[str, Any]) -> None:
+        if event.get("event") != "done" and event.get("type") != "done":
+            write_json_line(event)
+
+    return emit
+
+
+def _non_root_path(path: str, *, label: str = "研究路径") -> str:
+    normalized = normalize_research_path(path)
+    if not normalized:
+        raise UsageError(f"{label}不能是研究根目录")
+    return normalized
+
+
+def _read_upload(path: Path) -> tuple[Any, str, str]:
+    try:
+        if path.stat().st_size > MAX_UPLOAD_BYTES:
+            raise FileError(f"本地文件超过 25 MiB 上传限制：{path}")
+        raw = path.read_bytes()
+        if path.stat().st_size > MAX_UPLOAD_BYTES or len(raw) > MAX_UPLOAD_BYTES:
+            raise FileError(f"本地文件超过 25 MiB 上传限制：{path}")
+    except OSError as exc:
+        raise FileError(f"无法读取本地文件 {path}") from exc
+
+    if path.suffix.lower() == ".ipynb":
+        try:
+            notebook = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, ValueError) as exc:
+            raise FileError(f"Notebook 不是有效的 UTF-8 JSON：{path}") from exc
+        if not isinstance(notebook, dict):
+            raise FileError(f"Notebook 顶层必须是 JSON 对象：{path}")
+        return notebook, "notebook", "json"
+
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return base64.b64encode(raw).decode("ascii"), "file", "base64"
+    if "\x00" in text:
+        return base64.b64encode(raw).decode("ascii"), "file", "base64"
+    return text, "file", "text"
+
+
+def _write_result(app: AppContext, payload: dict[str, Any], message: str) -> None:
+    if app.json_output:
+        write_json(payload)
+    elif not app.quiet:
+        click.echo(message)
+
+
+@research_group.command("ls")
+@click.argument("path", required=False, default="")
+@click.pass_obj
+def ls(app: AppContext, path: str) -> None:
+    client = make_client(app)
+    try:
+        payload = list_research_items(client, path=path)
+    finally:
+        close_client(client)
+    if app.json_output:
+        write_json(payload)
+    else:
+        items = payload.get("items") if isinstance(payload.get("items"), list) else []
+        render_research_table(items)
+
+
+@research_group.command("kernelspecs")
+@click.pass_obj
+def kernelspecs(app: AppContext) -> None:
+    """列出研究平台可用的内核规格。"""
+    client = make_client(app)
+    try:
+        payload = list_research_kernelspecs(client)
+    finally:
+        close_client(client)
+    if app.json_output:
+        write_json(payload)
+    else:
+        render_kernelspecs_table(payload)
+
+
+@research_group.command("kernels")
+@click.pass_obj
+def kernels(app: AppContext) -> None:
+    """只读列出当前研究内核；不会连接或修改内核。"""
+    client = make_client(app)
+    try:
+        payload = list_research_kernels(client)
+    finally:
+        close_client(client)
+    if app.json_output:
+        write_json(payload)
+    else:
+        render_kernels_table(payload)
+
+
+@research_group.command("sessions")
+@click.pass_obj
+def sessions(app: AppContext) -> None:
+    """只读列出当前研究会话；不会连接或修改会话。"""
+    client = make_client(app)
+    try:
+        payload = list_research_sessions(client)
+    finally:
+        close_client(client)
+    if app.json_output:
+        write_json(payload)
+    else:
+        render_sessions_table(payload)
+
+
+@research_group.command("show")
+@click.argument("path")
+@click.option("--content", "include_content", is_flag=True, help="同时读取并显示内容")
+@click.pass_obj
+def show(app: AppContext, path: str, include_content: bool) -> None:
+    client = make_client(app)
+    try:
+        payload = get_research_item(client, path, include_content=include_content)
+    finally:
+        close_client(client)
+    if app.json_output:
+        write_json(payload)
+    else:
+        render_research_item(payload, include_content=include_content)
+
+
+@research_group.command("download")
+@click.argument("path")
+@click.option("--output", "-o", type=click.Path(dir_okay=False, path_type=str), help="本地输出文件")
+@click.option("--force", is_flag=True, help="覆盖已存在的本地文件")
+@click.pass_obj
+def download(app: AppContext, path: str, output: str | None, force: bool) -> None:
+    client = make_client(app)
+    try:
+        payload = get_research_item(client, path, include_content=True)
+    finally:
+        close_client(client)
+
+    data = _download_bytes(payload)
+    output_path = Path(output) if output else Path(_safe_basename(payload, path))
+    if output_path.exists() and not force:
+        raise FileError(f"输出文件已存在：{output_path}")
+    try:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("wb" if force else "xb") as output_file:
+            output_file.write(data)
+    except FileExistsError:
+        raise FileError(f"输出文件已存在：{output_path}") from None
+    except OSError as exc:
+        raise FileError(f"无法写入文件 {output_path}") from exc
+
+    receipt = {
+        "path": str(payload.get("path") or path),
+        "output": str(output_path),
+        "bytes": len(data),
+    }
+    if app.json_output:
+        write_json(receipt)
+    elif not app.quiet:
+        click.echo(f"已下载 {receipt['path']} -> {receipt['output']}（{receipt['bytes']} bytes）")
+
+
+@research_group.command("exec")
+@click.option("--file", "local_file", type=click.Path(dir_okay=False, path_type=str), help="读取 UTF-8 Python 文件")
+@click.option("--code-stdin", is_flag=True, help="从标准输入读取 UTF-8 代码；必须同时传 --yes")
+@click.option("--kernel", "kernel_name", help="临时内核规格名称；默认使用平台默认值")
+@click.option(
+    "--execution-timeout",
+    type=float,
+    default=DEFAULT_EXECUTION_TIMEOUT,
+    show_default=True,
+    help="远端执行总超时秒数",
+)
+@click.option("--stream", "stream_output", is_flag=True, help="以 JSONL 逐条输出交互事件；仅支持 JSON 格式")
+@click.option("--yes", "yes", is_flag=True, help="确认在临时远端会话和内核中执行代码")
+@click.pass_obj
+def exec_code(
+    app: AppContext,
+    local_file: str | None,
+    code_stdin: bool,
+    kernel_name: str | None,
+    execution_timeout: float,
+    stream_output: bool,
+    yes: bool,
+) -> None:
+    """在自动清理的临时研究会话和内核中执行代码。"""
+    if bool(local_file) == bool(code_stdin):
+        raise UsageError("必须且只能指定 --file 或 --code-stdin 之一")
+    if stream_output and not app.json_output:
+        raise UsageError("--stream 仅支持 --format json")
+    execution_timeout = _validate_execution_timeout(execution_timeout)
+    _confirm_execution(yes)
+    code = _read_execution_code(local_file, code_stdin)
+    callback = _stream_callback() if stream_output else None
+
+    client = make_client(app)
+    try:
+        payload = execute_research_code(
+            client,
+            code,
+            kernel_name=kernel_name,
+            execution_timeout=execution_timeout,
+            on_event=callback,
+        )
+    finally:
+        close_client(client)
+
+    if stream_output:
+        write_json_line({"event": "done", "result": payload})
+    elif app.json_output:
+        write_json(payload)
+    elif not app.quiet:
+        render_execution_result(payload)
+
+
+@research_group.command("run")
+@click.argument("path")
+@click.option("--cell", "cells", type=int, multiple=True, help="仅运行指定的 Notebook 原始零基单元格索引；可重复")
+@click.option("--kernel", "kernel_name", help="临时内核规格名称；默认使用 Notebook 元数据或平台默认值")
+@click.option(
+    "--execution-timeout",
+    type=float,
+    default=DEFAULT_EXECUTION_TIMEOUT,
+    show_default=True,
+    help="Notebook 远端执行总超时秒数",
+)
+@click.option("--stream", "stream_output", is_flag=True, help="以 JSONL 逐条输出交互事件；仅支持 JSON 格式")
+@click.option("--yes", "yes", is_flag=True, help="确认在临时远端会话中运行 Notebook")
+@click.pass_obj
+def run_notebook(
+    app: AppContext,
+    path: str,
+    cells: tuple[int, ...],
+    kernel_name: str | None,
+    execution_timeout: float,
+    stream_output: bool,
+    yes: bool,
+) -> None:
+    """在自动清理的临时研究会话中运行远端 Notebook；不保存输出。"""
+    path = _non_root_path(path, label="Notebook 路径")
+    selected_cells = _validate_cells(cells)
+    if stream_output and not app.json_output:
+        raise UsageError("--stream 仅支持 --format json")
+    execution_timeout = _validate_execution_timeout(execution_timeout)
+    _confirm_execution(yes)
+    callback = _stream_callback() if stream_output else None
+
+    client = make_client(app)
+    try:
+        payload = run_research_notebook(
+            client,
+            path,
+            cell_indexes=selected_cells,
+            kernel_name=kernel_name,
+            execution_timeout=execution_timeout,
+            on_event=callback,
+        )
+    finally:
+        close_client(client)
+
+    if stream_output:
+        write_json_line({"event": "done", "result": payload})
+    elif app.json_output:
+        write_json(payload)
+    elif not app.quiet:
+        render_execution_result(payload)
+
+
+@research_group.command("upload")
+@click.argument("local_path", type=click.Path(exists=True, dir_okay=False, path_type=str))
+@click.argument("remote_path", required=False)
+@click.option("--force", is_flag=True, help="覆盖已存在的远端项目")
+@click.option("--yes", "-y", is_flag=True, help="确认写入研究平台")
+@click.pass_obj
+def upload(app: AppContext, local_path: str, remote_path: str | None, force: bool, yes: bool) -> None:
+    local = Path(local_path)
+    destination = _non_root_path(remote_path or local.name, label="远端路径")
+    _confirm_write(app, yes, f"确认上传 {local} 到研究平台 {destination}？")
+    content, item_type, content_format = _read_upload(local)
+
+    client = make_client(app)
+    try:
+        try:
+            existing = get_research_item(client, destination, include_content=False)
+        except NotFoundError:
+            existing = None
+        if existing is not None:
+            if existing.get("type") == "directory":
+                raise FileError(f"远端目标是目录，不能覆盖：{destination}")
+            if not force:
+                raise FileError(f"远端项目已存在：{destination}；如需覆盖请传入 --force")
+        payload = save_research_item(
+            client,
+            destination,
+            content=content,
+            item_type=item_type,
+            content_format=content_format,
+        )
+    finally:
+        close_client(client)
+    _write_result(app, payload, f"已上传到研究平台：{payload.get('path', destination)}")
+
+
+@research_group.command("mkdir")
+@click.argument("path")
+@click.option("--yes", "-y", is_flag=True, help="确认创建远端目录")
+@click.pass_obj
+def mkdir(app: AppContext, path: str, yes: bool) -> None:
+    path = _non_root_path(path)
+    _confirm_write(app, yes, f"确认在研究平台创建目录 {path}？")
+    client = make_client(app)
+    try:
+        payload = create_research_directory(client, path)
+    finally:
+        close_client(client)
+    _write_result(app, payload, f"研究目录已创建：{payload.get('path', path)}")
+
+
+@research_group.command("mv")
+@click.argument("source")
+@click.argument("destination")
+@click.option("--yes", "-y", is_flag=True, help="确认移动或重命名远端项目")
+@click.pass_obj
+def mv(app: AppContext, source: str, destination: str, yes: bool) -> None:
+    source = _non_root_path(source, label="源路径")
+    destination = _non_root_path(destination, label="目标路径")
+    _confirm_write(app, yes, f"确认在研究平台移动 {source} 到 {destination}？")
+    client = make_client(app)
+    try:
+        payload = move_research_item(client, source, destination)
+    finally:
+        close_client(client)
+    _write_result(app, payload, f"研究项目已移动：{payload.get('path', destination)}")
+
+
+@research_group.command("rm")
+@click.argument("path")
+@click.option("--yes", "-y", is_flag=True, help="确认删除远端项目")
+@click.pass_obj
+def rm(app: AppContext, path: str, yes: bool) -> None:
+    path = _non_root_path(path)
+    _confirm_write(app, yes, f"确认删除研究平台项目 {path}？")
+    client = make_client(app)
+    try:
+        payload = delete_research_item(client, path) or {"ok": True, "path": path}
+    finally:
+        close_client(client)
+    _write_result(app, payload, f"研究项目已删除：{payload.get('path', path)}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "jqcli"
 version = "0.1.0"
-description = "JoinQuant strategy and backtest management CLI"
+description = "JoinQuant strategy, backtest, and research workspace management CLI"
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
@@ -13,6 +13,7 @@ dependencies = [
   "Flask>=3.0",
   "httpx>=0.27",
   "rich>=13.7",
+  "websockets>=15,<16",
 ]
 
 [project.optional-dependencies]
@@ -23,8 +24,11 @@ test = [
 [project.scripts]
 jqcli = "jqcli.cli:main"
 
-[tool.setuptools]
-packages = ["jqcli"]
+[tool.setuptools.packages.find]
+include = ["jqcli*"]
+
+[tool.setuptools.package-data]
+"jqcli.web" = ["templates/*.html", "static/*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_api/test_client.py
+++ b/tests/test_api/test_client.py
@@ -18,6 +18,422 @@ def test_client_adds_auth_header():
     assert client.get("/ping") == {"ok": True}
 
 
+def test_client_sends_configured_cookie():
+    def handler(request):
+        assert request.headers["cookie"] == "sid=abc; theme=dark"
+        return httpx.Response(200, json={"ok": True})
+
+    client = ApiClient(
+        "https://example.test",
+        cookie="sid=abc; theme=dark",
+        transport=httpx.MockTransport(handler),
+    )
+
+    assert client.get("/ping") == {"ok": True}
+
+
+@pytest.mark.parametrize(
+    "cookie",
+    [
+        "sid=specific; sid=root",
+        r'sid="abc\073def"',
+    ],
+)
+def test_client_preserves_duplicate_and_quoted_cookie_header_values(cookie):
+    def handler(request):
+        assert request.headers["cookie"] == cookie
+        return httpx.Response(200, json={"ok": True})
+
+    client = ApiClient(
+        "https://example.test",
+        cookie=cookie,
+        transport=httpx.MockTransport(handler),
+    )
+
+    assert client.get("/ping") == {"ok": True}
+
+
+@pytest.mark.parametrize("target", ["https://other.test/ping", "https://sub.example.test/ping"])
+def test_client_rejects_cross_origin_request_before_sending_credentials(target):
+    def handler(request):
+        raise AssertionError("cross-origin request must not be sent")
+
+    client = ApiClient(
+        "https://example.test",
+        cookie="sid=abc",
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(ApiError):
+        client.get(target)
+
+
+def test_client_rejects_automatic_redirect_following():
+    client = make_client(lambda request: httpx.Response(200, json={"ok": True}))
+
+    with pytest.raises(ApiError):
+        client.get("/ping", follow_redirects=True)
+
+
+def test_client_rejects_absolute_url_with_userinfo():
+    client = make_client(lambda request: pytest.fail("userinfo URL must not be requested"))
+
+    with pytest.raises(ApiError):
+        client.get("https://user:password@example.test/ping")
+
+
+def test_client_maps_malformed_absolute_url_to_api_error():
+    client = make_client(lambda request: pytest.fail("malformed URL must not be requested"))
+
+    with pytest.raises(ApiError):
+        client.get("https://example.test:invalid/ping")
+
+
+def test_client_keeps_cookies_set_during_session():
+    requests = []
+
+    def handler(request):
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx.Response(200, text="ok", headers={"set-cookie": "research=ready; Path=/"})
+        return httpx.Response(200, json={"ok": True})
+
+    client = ApiClient(
+        "https://example.test",
+        cookie="sid=abc",
+        transport=httpx.MockTransport(handler),
+    )
+
+    client.get_text("/bootstrap")
+    assert client.get("/ping") == {"ok": True}
+    assert set(requests[1].headers["cookie"].split("; ")) == {"sid=abc", "research=ready"}
+    assert client.get_cookie("research") == "ready"
+    assert client.get_cookie("missing") is None
+
+
+def test_client_cookie_header_getter_is_path_aware_and_rejects_cross_origin():
+    client = ApiClient(
+        "https://example.test",
+        cookie="sid=private",
+        transport=httpx.MockTransport(lambda request: httpx.Response(200)),
+    )
+    client._client.cookies.set("narrow", "value", domain="example.test", path="/user/tester/")
+
+    assert client.get_cookie_header("/outside") == "sid=private"
+    assert set(client.get_cookie_header("/user/tester/api").split("; ")) == {
+        "sid=private",
+        "narrow=value",
+    }
+    with pytest.raises(ApiError):
+        client.get_cookie_header("https://evil.example/capture")
+
+
+def test_client_preserves_raw_initial_cookie_when_merging_a_distinct_session_cookie():
+    requests = []
+    initial = r'sid=specific;  sid=root; encoded="abc\073def"'
+
+    def handler(request):
+        requests.append(request)
+        if len(requests) == 1:
+            assert request.headers["cookie"] == initial
+            return httpx.Response(200, text="ok", headers={"set-cookie": "research=ready; Path=/"})
+        return httpx.Response(200, json={"ok": True})
+
+    client = ApiClient(
+        "https://example.test",
+        cookie=initial,
+        transport=httpx.MockTransport(handler),
+    )
+
+    client.get_text("/bootstrap")
+    assert client.get("/ping") == {"ok": True}
+    assert requests[1].headers["cookie"] == f"{initial}; research=ready"
+
+
+def test_client_replaces_initial_cookie_after_server_sets_the_same_name():
+    requests = []
+    initial = "prefs=O'Reilly; sid=old"
+
+    def handler(request):
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx.Response(200, text="ok", headers={"set-cookie": "sid=new; Path=/"})
+        return httpx.Response(200, json={"ok": True})
+
+    client = ApiClient(
+        "https://example.test",
+        cookie=initial,
+        transport=httpx.MockTransport(handler),
+    )
+
+    client.get_text("/bootstrap")
+    assert client.get("/ping") == {"ok": True}
+    assert requests[1].headers["cookie"] == "prefs=O'Reilly; sid=new"
+
+
+def test_client_never_restores_initial_cookie_after_root_session_value_expires():
+    requests = []
+
+    def handler(request):
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx.Response(
+                200,
+                text="ok",
+                headers={"set-cookie": "sid=new; Max-Age=1; Path=/"},
+            )
+        return httpx.Response(200, json={"ok": True})
+
+    client = ApiClient(
+        "https://example.test",
+        cookie="sid=old; keep=yes",
+        transport=httpx.MockTransport(handler),
+    )
+
+    client.get_text("/bootstrap")
+    client._client.cookies.clear()  # Deterministically simulate expiry of sid=new.
+    assert client.get("/next") == {"ok": True}
+    assert requests[1].headers["cookie"] == "keep=yes"
+
+
+def test_client_keeps_host_initial_cookie_beside_parent_domain_session_cookie():
+    requests = []
+
+    def handler(request):
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx.Response(
+                200,
+                text="ok",
+                headers={"set-cookie": "sid=domain; Domain=.example.test; Path=/"},
+            )
+        return httpx.Response(200, json={"ok": True})
+
+    client = ApiClient(
+        "https://sub.example.test",
+        cookie="sid=host",
+        transport=httpx.MockTransport(handler),
+    )
+
+    client.get_text("/bootstrap")
+    assert client.get("/next") == {"ok": True}
+    assert requests[1].headers["cookie"] == "sid=host; sid=domain"
+
+
+def test_client_interleaves_narrow_initial_and_parent_domain_cookie_paths():
+    requests = []
+
+    def handler(request):
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx.Response(
+                200,
+                text="ok",
+                headers=httpx.Headers(
+                    [
+                        ("set-cookie", "sid=narrow; Path=/research/"),
+                        ("set-cookie", "sid=domain; Domain=.example.test; Path=/"),
+                    ]
+                ),
+            )
+        return httpx.Response(200, json={"ok": True})
+
+    client = ApiClient(
+        "https://sub.example.test",
+        cookie="sid=host",
+        transport=httpx.MockTransport(handler),
+    )
+
+    client.get_text("/bootstrap")
+    assert client.get("/research/item") == {"ok": True}
+    assert requests[1].headers["cookie"] == "sid=narrow; sid=host; sid=domain"
+
+
+def test_client_does_not_restore_an_initial_cookie_deleted_by_the_server():
+    requests = []
+
+    def handler(request):
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx.Response(
+                200,
+                text="ok",
+                headers={"set-cookie": "sid=gone; Max-Age=0; Path=/"},
+            )
+        return httpx.Response(200, json={"ok": True})
+
+    client = ApiClient(
+        "https://example.test",
+        cookie="sid=old",
+        transport=httpx.MockTransport(handler),
+    )
+
+    client.get_text("/bootstrap")
+    assert client.get("/ping") == {"ok": True}
+    assert "cookie" not in requests[1].headers
+
+
+@pytest.mark.parametrize(
+    "set_cookie",
+    [
+        "sid=new; Domain=.test; Path=/",
+        "sid=new; Path=relative",
+        "sid=new; Max-Age=abc; Path=/",
+    ],
+)
+def test_client_does_not_suppress_initial_cookie_for_rejected_set_cookie(set_cookie):
+    requests = []
+
+    def handler(request):
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx.Response(200, text="ok", headers={"set-cookie": set_cookie})
+        return httpx.Response(200, json={"ok": True})
+
+    client = ApiClient(
+        "https://example.test",
+        cookie="sid=old; keep=yes",
+        transport=httpx.MockTransport(handler),
+    )
+
+    client.get_text("/bootstrap")
+    assert client.get("/next") == {"ok": True}
+    assert requests[1].headers["cookie"] == "sid=old; keep=yes"
+
+
+@pytest.mark.parametrize(
+    "set_cookie",
+    [
+        "sid=gone; Max-Age=0; Domain=; Path=/",
+        "sid=gone; Max-Age=0; Domain=.; Path=/",
+        "sid=gone; Max-Age=0; Domain=..example.test; Path=/",
+        "sid=gone; Max-Age=0; Domain=.example.test; Path=/",
+    ],
+)
+def test_client_domain_deletion_does_not_remove_modeled_host_initial_cookie(set_cookie):
+    requests = []
+
+    def handler(request):
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx.Response(200, text="ok", headers={"set-cookie": set_cookie})
+        return httpx.Response(200, json={"ok": True})
+
+    client = ApiClient(
+        "https://example.test",
+        cookie="sid=host",
+        transport=httpx.MockTransport(handler),
+    )
+
+    client.get_text("/bootstrap")
+    assert client.get("/next") == {"ok": True}
+    assert requests[1].headers["cookie"] == "sid=host"
+
+
+def test_client_models_initial_cookie_as_root_when_a_narrow_cookie_is_deleted():
+    requests = []
+
+    def handler(request):
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx.Response(
+                200,
+                text="ok",
+                headers={"set-cookie": "sid=gone; Max-Age=0; Path=/research/"},
+            )
+        return httpx.Response(200, json={"ok": True})
+
+    client = ApiClient(
+        "https://example.test",
+        cookie="sid=root",
+        transport=httpx.MockTransport(handler),
+    )
+
+    client.get_text("/bootstrap")
+    assert client.get("/research/item") == {"ok": True}
+    assert requests[1].headers["cookie"] == "sid=root"
+
+
+def test_client_orders_narrow_session_cookie_before_initial_root_cookie():
+    requests = []
+
+    def handler(request):
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx.Response(
+                200,
+                text="ok",
+                headers={"set-cookie": "sid=specific; Path=/research/"},
+            )
+        return httpx.Response(200, json={"ok": True})
+
+    client = ApiClient(
+        "https://example.test",
+        cookie="sid=root",
+        transport=httpx.MockTransport(handler),
+    )
+
+    client.get_text("/bootstrap")
+    assert client.get("/research/item") == {"ok": True}
+    assert requests[1].headers["cookie"] == "sid=specific; sid=root"
+    assert client.get_cookie("sid", "/research/item") == "root"
+
+
+def test_client_get_cookie_matches_the_actual_request_path():
+    def handler(request):
+        return httpx.Response(
+            200,
+            json={"ok": True},
+            headers=httpx.Headers(
+                [
+                    ("set-cookie", "_xsrf=wrong; Path=/unrelated/very/long/path/"),
+                    ("set-cookie", "_xsrf=correct; Path=/user/tester/"),
+                ]
+            ),
+        )
+
+    client = ApiClient("https://example.test", transport=httpx.MockTransport(handler))
+    client.get("/bootstrap")
+
+    assert client.get_cookie("_xsrf", "/user/tester/api/contents/demo.ipynb") == "correct"
+    assert client.get_cookie("_xsrf", "/unrelated/very/long/path/item") == "wrong"
+
+
+def test_client_get_cookie_uses_server_last_wins_for_duplicate_matching_paths():
+    def handler(request):
+        return httpx.Response(
+            200,
+            json={"ok": True},
+            headers=httpx.Headers(
+                [
+                    ("set-cookie", "_xsrf=specific; Path=/user/tester/"),
+                    ("set-cookie", "_xsrf=root; Path=/"),
+                ]
+            ),
+        )
+
+    client = ApiClient("https://example.test", transport=httpx.MockTransport(handler))
+    client.get("/bootstrap")
+
+    assert client.get_cookie("_xsrf", "/user/tester/api/contents/demo.ipynb") == "root"
+
+
+def test_client_get_cookie_decodes_quoted_value_like_the_server():
+    client = ApiClient("https://example.test", cookie=r'_xsrf="abc\073def"')
+
+    assert client.get_cookie("_xsrf", "/user/tester/api/contents/demo.ipynb") == "abc;def"
+
+
+def test_client_patch_returns_json():
+    def handler(request):
+        assert request.method == "PATCH"
+        return httpx.Response(200, json={"ok": True})
+
+    client = make_client(handler)
+
+    assert client.patch("/item", json={"name": "new"}) == {"ok": True}
+
+
 def test_client_can_return_text_response():
     client = make_client(lambda request: httpx.Response(200, text="<html></html>"))
 
@@ -26,13 +442,39 @@ def test_client_can_return_text_response():
 
 @pytest.mark.parametrize(
     ("status_code", "error_type"),
-    [(401, NotAuthenticatedError), (403, NotAuthenticatedError), (404, NotFoundError), (500, ApiError)],
+    [
+        (302, ApiError),
+        (401, NotAuthenticatedError),
+        (403, NotAuthenticatedError),
+        (404, NotFoundError),
+        (500, ApiError),
+    ],
 )
 def test_client_maps_error_status(status_code, error_type):
     client = make_client(lambda request: httpx.Response(status_code, json={"error": "x"}))
 
     with pytest.raises(error_type):
         client.get("/x")
+
+
+def test_client_maps_login_redirect_to_not_authenticated():
+    client = make_client(
+        lambda request: httpx.Response(302, headers={"location": "/user/login/index"})
+    )
+
+    with pytest.raises(NotAuthenticatedError):
+        client.get("/private")
+
+
+def test_client_can_return_redirect_for_explicit_manual_handling():
+    client = make_client(
+        lambda request: httpx.Response(307, headers={"location": "/next"})
+    )
+
+    response = client.request_response("POST", "/start", allow_redirect_status=True, data={"x": "y"})
+
+    assert response.status_code == 307
+    assert response.headers["location"] == "/next"
 
 
 def test_client_maps_network_error():

--- a/tests/test_api/test_research.py
+++ b/tests/test_api/test_research.py
@@ -1,0 +1,599 @@
+import json
+from http.cookies import SimpleCookie
+from urllib.parse import parse_qs, quote
+
+import httpx
+import pytest
+
+from jqcli.api.client import ApiClient
+from jqcli.api.research import (
+    create_research_directory,
+    delete_research_item,
+    get_research_item,
+    list_research_items,
+    move_research_item,
+    normalize_research_path,
+    save_research_item,
+)
+from jqcli.errors import ApiError, NotAuthenticatedError, UsageError
+
+
+MOB = "13800138000"
+SESSION_ID = "one-time-session-secret"
+SSO_SCRIPT = f"""
+<script>
+var mob = '{MOB}';
+var sessionId = "{SESSION_ID}";
+Cy.postRedirect('/research/login', {{username: mob, token: sessionId}});
+</script>
+"""
+LOGIN_HTML = '<html><body data-base-url="/user/tester/"></body></html>'
+
+
+def contents_model(name: str, path: str, type_: str, *, content=None) -> dict:
+    return {
+        "name": name,
+        "path": path,
+        "type": type_,
+        "writable": True,
+        "created": "2026-08-01T01:02:03Z",
+        "last_modified": "2026-08-02T03:04:05Z",
+        "mimetype": None if type_ in {"directory", "notebook"} else "text/plain",
+        "format": "json" if type_ == "notebook" else None,
+        # Notebook 5.4.1 responses observed in production omit size.  Keeping it
+        # absent here verifies that the normalized API still exposes size=None.
+        "content": content,
+        "server_extension": "must not leak",
+    }
+
+
+def client_with_contents(contents_handler):
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        if request.url.path == "/default/research/redirect":
+            return httpx.Response(200, text=SSO_SCRIPT)
+        if request.url.path == "/research/login":
+            assert request.method == "POST"
+            assert parse_qs(request.content.decode()) == {"username": [MOB], "token": [SESSION_ID]}
+            return httpx.Response(200, text=LOGIN_HTML)
+        if request.url.path.startswith("/user/tester/api/contents"):
+            return contents_handler(request)
+        raise AssertionError(f"unexpected request: {request.method} {request.url}")
+
+    return ApiClient("https://example.test", token="api-token", transport=httpx.MockTransport(handler)), seen
+
+
+def client_with_write(
+    write_handler,
+    *,
+    set_xsrf: bool = True,
+    xsrf_cookie: str = '"%63srf%2Dvalue"',
+    unrelated_xsrf_cookie: str | None = None,
+    root_xsrf_cookie: str | None = None,
+):
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        if request.url.path == "/default/research/redirect":
+            return httpx.Response(200, text=SSO_SCRIPT)
+        if request.url.path == "/research/login":
+            return httpx.Response(200, text=LOGIN_HTML)
+        if request.url.path == "/user/tester/api":
+            cookie_headers = []
+            if set_xsrf:
+                cookie_headers.append(("set-cookie", f"_xsrf={xsrf_cookie}; Path=/user/tester/"))
+            if unrelated_xsrf_cookie is not None:
+                cookie_headers.append(
+                    (
+                        "set-cookie",
+                        f"_xsrf={unrelated_xsrf_cookie}; Path=/unrelated/very/long/path/",
+                    )
+                )
+            if root_xsrf_cookie is not None:
+                cookie_headers.append(("set-cookie", f"_xsrf={root_xsrf_cookie}; Path=/"))
+            headers = httpx.Headers(cookie_headers)
+            return httpx.Response(200, json={"version": "5.4.1"}, headers=headers)
+        if request.url.path.startswith("/user/tester/api/contents/"):
+            return write_handler(request)
+        raise AssertionError(f"unexpected request: {request.method} {request.url}")
+
+    return ApiClient("https://example.test", transport=httpx.MockTransport(handler)), seen
+
+
+def request_cookies(request: httpx.Request) -> dict[str, str]:
+    parsed = SimpleCookie()
+    parsed.load(request.headers.get("cookie", ""))
+    return {name: morsel.value for name, morsel in parsed.items()}
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("", ""),
+        ("///", ""),
+        ("/folder/file.ipynb/", "folder/file.ipynb"),
+        (r"\folder\nested\file.py", "folder/nested/file.py"),
+    ],
+)
+def test_normalize_research_path(value, expected):
+    assert normalize_research_path(value) == expected
+
+
+@pytest.mark.parametrize("value", ["folder//file", "folder/./file", "folder/../file", "folder/\x00file"])
+def test_normalize_research_path_rejects_unsafe_components(value):
+    with pytest.raises(UsageError):
+        normalize_research_path(value)
+
+
+def test_list_root_bootstraps_sso_follows_cookie_redirect_and_filters_items():
+    child = contents_model("策略.ipynb", "策略.ipynb", "notebook", content={"cells": []})
+    root = contents_model("", "", "directory", content=[child])
+    seen: list[tuple[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append((request.method, request.url.path))
+        if request.url.path == "/default/research/redirect":
+            assert request_cookies(request) == {"main_session": "keep"}
+            return httpx.Response(200, text=SSO_SCRIPT)
+        if request.url.path == "/research/login":
+            assert request.method == "POST"
+            assert parse_qs(request.content.decode()) == {"username": [MOB], "token": [SESSION_ID]}
+            assert request_cookies(request) == {"main_session": "keep"}
+            return httpx.Response(
+                302,
+                headers={"Location": "/research/tree", "Set-Cookie": "research_session=ready; Path=/"},
+            )
+        if request.url.path == "/research/tree":
+            assert request.method == "GET"
+            assert request_cookies(request) == {"main_session": "keep", "research_session": "ready"}
+            return httpx.Response(200, text=LOGIN_HTML)
+        if request.url.path == "/user/tester/api/contents":
+            assert dict(request.url.params) == {"content": "1"}
+            assert request_cookies(request) == {"main_session": "keep", "research_session": "ready"}
+            return httpx.Response(200, json=root)
+        raise AssertionError(request.url)
+
+    client = ApiClient(
+        "https://example.test",
+        cookie="main_session=keep",
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = list_research_items(client)
+
+    assert result == {
+        "path": "",
+        "items": [
+            {
+                "name": "策略.ipynb",
+                "path": "策略.ipynb",
+                "type": "notebook",
+                "writable": True,
+                "created": "2026-08-01T01:02:03Z",
+                "last_modified": "2026-08-02T03:04:05Z",
+                "mimetype": None,
+                "format": "json",
+                "size": None,
+            }
+        ],
+        "total": 1,
+    }
+    assert seen == [
+        ("GET", "/default/research/redirect"),
+        ("POST", "/research/login"),
+        ("GET", "/research/tree"),
+        ("GET", "/user/tester/api/contents"),
+    ]
+
+
+def test_list_supports_joinquant_named_sso_form_object():
+    script = f"""
+    <script>
+    var mob = '{MOB}';
+    var sessionId = '{SESSION_ID}';
+    var data = {{username: mob, token: sessionId}}
+    Cy.postRedirect('/research/login', data);
+    </script>
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/default/research/redirect":
+            return httpx.Response(200, text=script)
+        if request.url.path == "/research/login":
+            assert parse_qs(request.content.decode()) == {"username": [MOB], "token": [SESSION_ID]}
+            return httpx.Response(200, text=LOGIN_HTML)
+        if request.url.path == "/user/tester/api/contents":
+            return httpx.Response(200, json=contents_model("", "", "directory", content=[]))
+        raise AssertionError(request.url)
+
+    client = ApiClient("https://example.test", cookie="sid=abc", transport=httpx.MockTransport(handler))
+
+    assert list_research_items(client) == {"path": "", "items": [], "total": 0}
+
+
+def test_list_subdirectory_encodes_chinese_and_spaces_without_encoding_slashes():
+    directory = contents_model("子 目录", "研究 资料/子 目录", "directory", content=[])
+
+    def contents_handler(request: httpx.Request) -> httpx.Response:
+        encoded = quote("研究 资料/子 目录", safe="/").encode()
+        assert request.url.raw_path.split(b"?", 1)[0] == b"/user/tester/api/contents/" + encoded
+        assert dict(request.url.params) == {"content": "1"}
+        return httpx.Response(200, json=directory)
+
+    client, seen = client_with_contents(contents_handler)
+
+    result = list_research_items(client, r"/研究 资料\子 目录/")
+
+    assert result == {"path": "研究 资料/子 目录", "items": [], "total": 0}
+    assert [request.url.path for request in seen].count("/default/research/redirect") == 1
+
+
+def test_get_item_controls_content_and_bootstraps_once_per_call():
+    notebook_content = {"cells": [{"cell_type": "code", "source": ["print(1)"]}], "nbformat": 4}
+
+    def contents_handler(request: httpx.Request) -> httpx.Response:
+        requested = request.url.params["content"]
+        return httpx.Response(
+            200,
+            json=contents_model(
+                "demo.ipynb",
+                "demo.ipynb",
+                "notebook",
+                content=notebook_content if requested == "1" else None,
+            ),
+        )
+
+    client, seen = client_with_contents(contents_handler)
+
+    without_content = get_research_item(client, "/demo.ipynb/")
+    with_content = get_research_item(client, "demo.ipynb", include_content=True)
+
+    assert "content" not in without_content
+    assert with_content["content"] == notebook_content
+    assert [request.url.params["content"] for request in seen if "/api/contents" in request.url.path] == ["0", "1"]
+    assert [request.url.path for request in seen].count("/default/research/redirect") == 2
+
+
+@pytest.mark.parametrize(
+    "script",
+    [
+        "var mob='private-mob'; var sessionId='private-token';",
+        "var mob='private-mob'; Cy.postRedirect('/research/login', {username:mob, token:sessionId});",
+        "var mob='private-mob'; var sessionId='private-token'; Cy.postRedirect('/research/login', {user:mob});",
+    ],
+)
+def test_malformed_sso_is_not_authenticated_and_does_not_leak_secrets(script):
+    client = ApiClient(
+        "https://example.test",
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, text=script)),
+    )
+
+    with pytest.raises(NotAuthenticatedError) as captured:
+        list_research_items(client)
+
+    rendered = f"{captured.value!s} {captured.value!r} {captured.value.message} {captured.value.details}"
+    assert "private-mob" not in rendered
+    assert "private-token" not in rendered
+
+
+def test_cross_origin_sso_url_is_rejected_before_credentials_are_posted():
+    script = f"""
+    var mob='{MOB}';
+    var sessionId='{SESSION_ID}';
+    Cy.postRedirect('https://evil.example/research/login', {{username:mob,token:sessionId}});
+    """
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, text=script)
+
+    client = ApiClient("https://example.test", transport=httpx.MockTransport(handler))
+
+    with pytest.raises(ApiError) as captured:
+        list_research_items(client)
+
+    assert len(seen) == 1
+    rendered = f"{captured.value!s} {captured.value!r} {captured.value.message} {captured.value.details}"
+    assert MOB not in rendered
+    assert SESSION_ID not in rendered
+
+
+@pytest.mark.parametrize("status_code", [302, 307])
+def test_cross_origin_sso_redirect_is_rejected_before_following(status_code):
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        if request.url.path == "/default/research/redirect":
+            return httpx.Response(200, text=SSO_SCRIPT)
+        if request.url.path == "/research/login":
+            assert parse_qs(request.content.decode()) == {"username": [MOB], "token": [SESSION_ID]}
+            return httpx.Response(status_code, headers={"location": "https://evil.example/capture"})
+        raise AssertionError("cross-origin redirect must not be followed")
+
+    client = ApiClient("https://example.test", cookie="sid=abc", transport=httpx.MockTransport(handler))
+
+    with pytest.raises(ApiError) as captured:
+        list_research_items(client)
+
+    assert [request.url.host for request in seen] == ["example.test", "example.test"]
+    rendered = f"{captured.value!s} {captured.value!r} {captured.value.message}"
+    assert MOB not in rendered
+    assert SESSION_ID not in rendered
+
+
+def test_login_rejection_maps_to_not_authenticated_without_secret_leakage():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/default/research/redirect":
+            return httpx.Response(200, text=SSO_SCRIPT)
+        assert request.url.path == "/research/login"
+        return httpx.Response(403, text="bad token")
+
+    client = ApiClient("https://example.test", transport=httpx.MockTransport(handler))
+
+    with pytest.raises(NotAuthenticatedError) as captured:
+        get_research_item(client, "demo.ipynb")
+
+    rendered = f"{captured.value!s} {captured.value!r} {captured.value.message} {captured.value.details}"
+    assert MOB not in rendered
+    assert SESSION_ID not in rendered
+
+
+@pytest.mark.parametrize(
+    ("login_html", "error_type"),
+    [
+        ("<html><body></body></html>", NotAuthenticatedError),
+        ('<html><body data-base-url="/services/user/tester/"></body></html>', ApiError),
+        ('<html><body data-base-url="/user/../"></body></html>', ApiError),
+        ('<html><body data-base-url="https://evil.example/user/tester/"></body></html>', ApiError),
+    ],
+)
+def test_login_page_requires_one_safe_jupyter_user_base(login_html, error_type):
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/default/research/redirect":
+            return httpx.Response(200, text=SSO_SCRIPT)
+        return httpx.Response(200, text=login_html)
+
+    client = ApiClient("https://example.test", transport=httpx.MockTransport(handler))
+
+    with pytest.raises(error_type):
+        list_research_items(client)
+
+
+def test_invalid_contents_payload_raises_api_error():
+    client, _ = client_with_contents(lambda request: httpx.Response(200, json=["not", "a", "model"]))
+
+    with pytest.raises(ApiError):
+        get_research_item(client, "demo.ipynb")
+
+
+def test_list_rejects_non_directory_contents_model():
+    file_model = contents_model("file.py", "file.py", "file", content="print(1)")
+    client, _ = client_with_contents(lambda request: httpx.Response(200, json=file_model))
+
+    with pytest.raises(ApiError):
+        list_research_items(client, "file.py")
+
+
+def test_save_research_item_primes_xsrf_and_puts_exact_contents_model():
+    notebook_content = {"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 2}
+    saved = contents_model("研究 笔记.ipynb", "目录/研究 笔记.ipynb", "notebook")
+
+    def write_handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "PUT"
+        expected_path = quote("目录/研究 笔记.ipynb", safe="/").encode()
+        assert request.url.raw_path == b"/user/tester/api/contents/" + expected_path
+        assert request.headers["x-xsrftoken"] == "csrf-value"
+        assert json.loads(request.content) == {
+            "type": "notebook",
+            "format": "json",
+            "content": notebook_content,
+        }
+        return httpx.Response(201, json=saved)
+
+    client, seen = client_with_write(write_handler)
+
+    result = save_research_item(
+        client,
+        r"/目录\研究 笔记.ipynb/",
+        content=notebook_content,
+        item_type="notebook",
+        content_format="json",
+    )
+
+    assert result["path"] == "目录/研究 笔记.ipynb"
+    assert "content" not in result
+    assert [(request.method, request.url.path) for request in seen] == [
+        ("GET", "/default/research/redirect"),
+        ("POST", "/research/login"),
+        ("GET", "/user/tester/api"),
+        ("PUT", "/user/tester/api/contents/目录/研究 笔记.ipynb"),
+    ]
+
+
+def test_create_research_directory_uses_named_put():
+    created = contents_model("新目录", "父目录/新目录", "directory")
+
+    def write_handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "PUT"
+        assert json.loads(request.content) == {"type": "directory"}
+        assert request.headers["x-xsrftoken"] == "csrf-value"
+        return httpx.Response(201, json=created)
+
+    client, _ = client_with_write(write_handler)
+
+    result = create_research_directory(client, "父目录/新目录")
+
+    assert result["type"] == "directory"
+    assert result["path"] == "父目录/新目录"
+
+
+def test_move_research_item_patches_normalized_destination():
+    moved = contents_model("新 名称.py", "目标/新 名称.py", "file")
+
+    def write_handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "PATCH"
+        assert request.url.path == "/user/tester/api/contents/来源/旧.py"
+        assert json.loads(request.content) == {"path": "目标/新 名称.py"}
+        assert request.headers["x-xsrftoken"] == "csrf-value"
+        return httpx.Response(200, json=moved)
+
+    client, _ = client_with_write(write_handler)
+
+    result = move_research_item(client, "来源/旧.py", r"/目标\新 名称.py/")
+
+    assert result["path"] == "目标/新 名称.py"
+
+
+def test_delete_research_item_returns_none_for_jupyter_204():
+    def write_handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "DELETE"
+        assert request.url.path == "/user/tester/api/contents/临时.py"
+        assert request.headers["x-xsrftoken"] == "csrf-value"
+        return httpx.Response(204)
+
+    client, _ = client_with_write(write_handler)
+
+    assert delete_research_item(client, "临时.py") is None
+
+
+def test_delete_research_item_does_not_treat_login_redirect_as_success():
+    client, _ = client_with_write(
+        lambda request: httpx.Response(302, headers={"location": "/hub/login"})
+    )
+
+    with pytest.raises(NotAuthenticatedError):
+        delete_research_item(client, "临时.py")
+
+
+def test_delete_research_item_requires_documented_204_status():
+    client, _ = client_with_write(lambda request: httpx.Response(200, json={"ok": True}))
+
+    with pytest.raises(ApiError):
+        delete_research_item(client, "临时.py")
+
+
+def test_write_fails_before_mutation_when_xsrf_cookie_is_missing():
+    write_requests: list[httpx.Request] = []
+    client, seen = client_with_write(lambda request: write_requests.append(request), set_xsrf=False)
+
+    with pytest.raises(ApiError):
+        create_research_directory(client, "safe-directory")
+
+    assert write_requests == []
+    assert [(request.method, request.url.path) for request in seen] == [
+        ("GET", "/default/research/redirect"),
+        ("POST", "/research/login"),
+        ("GET", "/user/tester/api"),
+    ]
+
+
+def test_write_decodes_percent_encoded_xsrf_outer_quotes():
+    created = contents_model("folder", "folder", "directory")
+
+    def write_handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["x-xsrftoken"] == "csrf-value"
+        return httpx.Response(201, json=created)
+
+    client, _ = client_with_write(write_handler, xsrf_cookie="%22csrf-value%22")
+
+    assert create_research_directory(client, "folder")["path"] == "folder"
+
+
+def test_write_uses_xsrf_cookie_matching_the_contents_endpoint():
+    created = contents_model("folder", "folder", "directory")
+
+    def write_handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["x-xsrftoken"] == "csrf-value"
+        assert request_cookies(request)["_xsrf"] == "%63srf%2Dvalue"
+        return httpx.Response(201, json=created)
+
+    client, _ = client_with_write(
+        write_handler,
+        unrelated_xsrf_cookie="wrong-token",
+    )
+
+    assert create_research_directory(client, "folder")["path"] == "folder"
+
+
+def test_write_xsrf_header_matches_server_last_wins_cookie_value():
+    created = contents_model("folder", "folder", "directory")
+
+    def write_handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["x-xsrftoken"] == "root-value"
+        assert request_cookies(request)["_xsrf"] == "root-value"
+        return httpx.Response(201, json=created)
+
+    client, _ = client_with_write(
+        write_handler,
+        xsrf_cookie="specific-value",
+        root_xsrf_cookie="root-value",
+    )
+
+    assert create_research_directory(client, "folder")["path"] == "folder"
+
+
+def test_invalid_xsrf_cookie_does_not_leak_or_send_a_write():
+    write_requests: list[httpx.Request] = []
+    client, _ = client_with_write(
+        lambda request: write_requests.append(request),
+        xsrf_cookie="private-xsrf-secret%0Ainjected",
+    )
+
+    with pytest.raises(ApiError) as captured:
+        create_research_directory(client, "folder")
+
+    assert write_requests == []
+    rendered = f"{captured.value!s} {captured.value!r} {captured.value.message} {captured.value.details}"
+    assert "private-xsrf-secret" not in rendered
+
+
+def test_write_operations_reject_the_root_before_bootstrap():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("no request should be sent for an invalid write target")
+
+    client = ApiClient("https://example.test", transport=httpx.MockTransport(handler))
+
+    with pytest.raises(UsageError):
+        save_research_item(client, "/", content="", item_type="file", content_format="text")
+    with pytest.raises(UsageError):
+        create_research_directory(client, "")
+    with pytest.raises(UsageError):
+        move_research_item(client, "source", "/")
+    with pytest.raises(UsageError):
+        delete_research_item(client, "///")
+
+
+@pytest.mark.parametrize(
+    ("item_type", "content_format", "content"),
+    [
+        ("directory", "json", {}),
+        ("notebook", "text", {}),
+        ("notebook", "json", []),
+        ("notebook", "json", {"cells": [b"not-json"]}),
+        ("notebook", "json", {"metadata": {"score": float("nan")}}),
+        ("file", "json", "{}"),
+        ("file", "text", {"not": "text"}),
+        ("file", "base64", b"bm90LWEtdGV4dC12YWx1ZQ=="),
+    ],
+)
+def test_save_research_item_rejects_unsupported_payloads_before_bootstrap(
+    item_type, content_format, content
+):
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("invalid save payload must be rejected before API access")
+
+    client = ApiClient("https://example.test", transport=httpx.MockTransport(handler))
+
+    with pytest.raises(ApiError):
+        save_research_item(
+            client,
+            "item",
+            content=content,
+            item_type=item_type,
+            content_format=content_format,
+        )

--- a/tests/test_api/test_research_execution.py
+++ b/tests/test_api/test_research_execution.py
@@ -1,0 +1,641 @@
+import builtins
+import json
+import re
+from urllib.parse import parse_qs, urlsplit
+
+import httpx
+import pytest
+
+import jqcli.api.research_execution as execution_api
+from jqcli.api.client import ApiClient
+from jqcli.api.research_execution import (
+    execute_research_code,
+    list_research_kernels,
+    list_research_kernelspecs,
+    list_research_sessions,
+    run_research_notebook,
+)
+from jqcli.errors import ApiError, NetworkError, NotAuthenticatedError, TimeoutError, UsageError
+
+
+SSO_SCRIPT = """
+var mob = 'private-user';
+var sessionId = 'private-sso-token';
+Cy.postRedirect('/research/login', {username: mob, token: sessionId});
+"""
+LOGIN_HTML = '<html><body data-base-url="/user/tester/"></body></html>'
+
+
+def kernel_model(identifier="new-kernel", name="python3"):
+    return {
+        "id": identifier,
+        "name": name,
+        "last_activity": "2026-08-15T01:02:03Z",
+        "execution_state": "idle",
+        "connections": 0,
+        "private": "must-not-leak",
+    }
+
+
+def session_model(path, identifier="new-session", kernel_id="new-kernel"):
+    return {
+        "id": identifier,
+        "path": path,
+        "name": path.rsplit("/", 1)[-1],
+        "type": "notebook",
+        "kernel": kernel_model(kernel_id),
+        "private": "must-not-leak",
+    }
+
+
+def notebook_model(path="folder/demo.ipynb"):
+    return {
+        "name": path.rsplit("/", 1)[-1],
+        "path": path,
+        "type": "notebook",
+        "writable": True,
+        "created": "2026-08-01T01:02:03Z",
+        "last_modified": "2026-08-02T03:04:05Z",
+        "mimetype": None,
+        "format": "json",
+        "content": {
+            "cells": [
+                {"cell_type": "code", "source": ["value = 1\n", "value"], "outputs": []},
+                {"cell_type": "markdown", "source": ["# title"]},
+                {"cell_type": "code", "source": "value + 1", "outputs": []},
+            ],
+            "metadata": {},
+            "nbformat": 4,
+            "nbformat_minor": 2,
+        },
+    }
+
+
+class FakeResearchServer:
+    def __init__(self):
+        self.requests = []
+        self.kernels = []
+        self.sessions = []
+        self.contents = notebook_model()
+        self.kernel_create_status = 201
+        self.kernel_create_payload = kernel_model()
+        self.session_create_status = 201
+        self.session_create_payload = None
+        self.delete_status = 204
+        self.kernel_post_error = None
+        self.session_post_error = None
+        self.bootstrap_count = 0
+
+    def handler(self, request):
+        self.requests.append(request)
+        path = request.url.path
+        if path == "/default/research/redirect":
+            self.bootstrap_count += 1
+            return httpx.Response(200, text=SSO_SCRIPT)
+        if path == "/research/login":
+            return httpx.Response(200, text=LOGIN_HTML)
+        if path == "/user/tester/api":
+            return httpx.Response(
+                200,
+                json={"version": "5.4.1"},
+                headers={"set-cookie": "_xsrf=private-xsrf; Path=/user/tester/"},
+            )
+        if path == "/user/tester/api/kernelspecs":
+            return httpx.Response(
+                200,
+                json={
+                    "default": "python3",
+                    "kernelspecs": {
+                        "python3": {
+                            "spec": {
+                                "argv": ["private-command"],
+                                "display_name": "Python 3",
+                                "language": "python",
+                                "interrupt_mode": "signal",
+                                "env": {"PRIVATE": "secret"},
+                            },
+                            "resources": {"logo-64x64": "private-path"},
+                        }
+                    },
+                },
+            )
+        if path == "/user/tester/api/kernels":
+            if request.method == "GET":
+                return httpx.Response(200, json=self.kernels)
+            assert request.method == "POST"
+            assert request.headers["x-xsrftoken"] == "private-xsrf"
+            if self.kernel_post_error is not None:
+                raise self.kernel_post_error("simulated transport failure", request=request)
+            return httpx.Response(self.kernel_create_status, json=self.kernel_create_payload)
+        if path == "/user/tester/api/sessions":
+            if request.method == "GET":
+                return httpx.Response(200, json=self.sessions)
+            assert request.method == "POST"
+            assert request.headers["x-xsrftoken"] == "private-xsrf"
+            body = json.loads(request.content)
+            if self.session_post_error is not None:
+                created = session_model(body["path"])
+                self.sessions = [created]
+                raise self.session_post_error("simulated transport failure", request=request)
+            payload = self.session_create_payload or session_model(body["path"])
+            return httpx.Response(self.session_create_status, json=payload)
+        if path.startswith("/user/tester/api/kernels/") or path.startswith(
+            "/user/tester/api/sessions/"
+        ):
+            assert request.method == "DELETE"
+            assert request.headers["x-xsrftoken"] == "private-xsrf"
+            return httpx.Response(self.delete_status)
+        if path.startswith("/user/tester/api/contents/"):
+            assert request.method == "GET"
+            assert request.url.params["content"] == "1"
+            return httpx.Response(200, json=self.contents)
+        raise AssertionError(f"unexpected request: {request.method} {request.url}")
+
+    def client(self):
+        return ApiClient(
+            "https://example.test",
+            token="private-bearer",
+            cookie="main_session=private-cookie",
+            transport=httpx.MockTransport(self.handler),
+        )
+
+
+def message(request, message_type, channel, content):
+    return {
+        "header": {"msg_type": message_type},
+        "parent_header": {"msg_id": request["header"]["msg_id"]},
+        "metadata": {},
+        "content": content,
+        "channel": channel,
+    }
+
+
+def binary_frame(payload, *buffers):
+    json_bytes = json.dumps(payload).encode("utf-8")
+    chunks = (json_bytes,) + buffers
+    count = len(chunks)
+    header_size = 4 * (count + 1)
+    offsets = []
+    offset = header_size
+    for chunk in chunks:
+        offsets.append(offset)
+        offset += len(chunk)
+    header = count.to_bytes(4, "big") + b"".join(value.to_bytes(4, "big") for value in offsets)
+    return header + b"".join(chunks)
+
+
+def success_messages(request, execution_count=1):
+    idle = message(request, "status", "iopub", {"execution_state": "idle"})
+    return [
+        json.dumps(message(request, "status", "iopub", {"execution_state": "busy"})),
+        json.dumps(message(request, "stream", "iopub", {"name": "stdout", "text": "hello\n"})),
+        json.dumps(
+            message(
+                request,
+                "execute_result",
+                "iopub",
+                {
+                    "execution_count": execution_count,
+                    "data": {"text/plain": "2"},
+                    "metadata": {},
+                },
+            )
+        ),
+        json.dumps(
+            message(
+                request,
+                "execute_reply",
+                "shell",
+                {"status": "ok", "execution_count": execution_count},
+            )
+        ),
+        binary_frame(idle, b"ignored-buffer"),
+    ]
+
+
+class FakeSocket:
+    def __init__(self, builder, *, timeout=False):
+        self.builder = builder
+        self.timeout = timeout
+        self.messages = []
+        self.sent = []
+        self.closed = False
+
+    def send(self, raw):
+        request = json.loads(raw)
+        self.sent.append(request)
+        self.messages.extend(self.builder(request, len(self.sent)))
+
+    def recv(self, timeout):
+        assert timeout > 0
+        if self.timeout:
+            raise builtins.TimeoutError
+        if not self.messages:
+            raise AssertionError("fake websocket message queue is empty")
+        return self.messages.pop(0)
+
+    def close(self):
+        self.closed = True
+
+
+class FakeConnector:
+    def __init__(self, builder=success_messages, *, timeout=False):
+        self.socket = FakeSocket(builder, timeout=timeout)
+        self.calls = []
+
+    def __call__(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        return self.socket
+
+
+def delete_requests(server):
+    return [request for request in server.requests if request.method == "DELETE"]
+
+
+def test_list_runtime_metadata_is_sanitized_and_read_only():
+    server = FakeResearchServer()
+    server.kernels = [kernel_model("existing-kernel")]
+    server.sessions = [session_model("existing.ipynb", "existing-session", "existing-kernel")]
+    client = server.client()
+
+    specs = list_research_kernelspecs(client)
+    kernels = list_research_kernels(client)
+    sessions = list_research_sessions(client)
+
+    assert specs == {
+        "default": "python3",
+        "items": [
+            {
+                "name": "python3",
+                "display_name": "Python 3",
+                "language": "python",
+                "interrupt_mode": "signal",
+            }
+        ],
+        "total": 1,
+    }
+    assert kernels["items"][0]["id"] == "existing-kernel"
+    assert sessions["items"][0]["kernel"]["id"] == "existing-kernel"
+    assert "private-command" not in json.dumps(specs)
+    assert delete_requests(server) == []
+
+
+def test_execute_collects_outputs_uses_exact_origin_cookie_only_and_cleans_up():
+    server = FakeResearchServer()
+    connector = FakeConnector()
+    events = []
+
+    result = execute_research_code(
+        server.client(),
+        "print('hello'); 1 + 1",
+        kernel_name="python3",
+        execution_timeout=10,
+        on_event=events.append,
+        _websocket_connect=connector,
+    )
+
+    assert result == {
+        "status": "ok",
+        "execution_count": 1,
+        "outputs": [
+            {"output_type": "stream", "name": "stdout", "text": "hello\n"},
+            {
+                "output_type": "execute_result",
+                "execution_count": 1,
+                "data": {"text/plain": "2"},
+                "metadata": {},
+            },
+        ],
+    }
+    assert [event["event"] for event in events] == [
+        "status",
+        "output",
+        "output",
+        "execute_reply",
+        "status",
+    ]
+    url, kwargs = connector.calls[0]
+    parsed = urlsplit(url)
+    assert parsed.scheme == "wss"
+    assert parsed.netloc == "example.test"
+    assert parsed.path == "/user/tester/api/kernels/new-kernel/channels"
+    assert len(parse_qs(parsed.query)["session_id"][0]) == 32
+    assert kwargs["origin"] == "https://example.test"
+    assert kwargs["proxy"] is None
+    assert set(kwargs["additional_headers"]) == {"Cookie"}
+    assert "private-bearer" not in str(kwargs)
+    assert connector.socket.sent[0]["content"]["allow_stdin"] is False
+    assert connector.socket.sent[0]["content"]["code"] == "print('hello'); 1 + 1"
+    assert connector.socket.closed is True
+    assert len(delete_requests(server)) == 1
+    assert delete_requests(server)[0].url.path == "/user/tester/api/sessions/new-session"
+    session_posts = [
+        request
+        for request in server.requests
+        if request.method == "POST" and request.url.path == "/user/tester/api/sessions"
+    ]
+    assert len(session_posts) == 1
+    posted_session = json.loads(session_posts[0].content)
+    assert posted_session["name"] == ""
+    assert posted_session["type"] == "notebook"
+    assert posted_session["kernel"] == {"name": "python3"}
+    assert re.fullmatch(
+        r"__jqcli_exec_[0-9a-f]{32}\.ipynb",
+        posted_session["path"],
+    )
+    assert not any(
+        request.method == "POST" and request.url.path == "/user/tester/api/kernels"
+        for request in server.requests
+    )
+    assert "new-kernel" not in json.dumps(result)
+    assert "private-cookie" not in json.dumps(result)
+
+
+def test_execute_returns_kernel_error_as_notebook_output_and_cleans_up():
+    def builder(request, _):
+        return [
+            json.dumps(
+                message(
+                    request,
+                    "error",
+                    "iopub",
+                    {"ename": "ValueError", "evalue": "bad", "traceback": ["trace"]},
+                )
+            ),
+            json.dumps(
+                message(
+                    request,
+                    "execute_reply",
+                    "shell",
+                    {"status": "error", "execution_count": 3},
+                )
+            ),
+            json.dumps(message(request, "status", "iopub", {"execution_state": "idle"})),
+        ]
+
+    server = FakeResearchServer()
+    result = execute_research_code(
+        server.client(), "raise ValueError('bad')", _websocket_connect=FakeConnector(builder)
+    )
+
+    assert result["status"] == "error"
+    assert result["outputs"] == [
+        {
+            "output_type": "error",
+            "ename": "ValueError",
+            "evalue": "bad",
+            "traceback": ["trace"],
+        }
+    ]
+    assert len(delete_requests(server)) == 1
+
+
+def test_execute_timeout_and_input_request_both_cleanup():
+    timeout_server = FakeResearchServer()
+    with pytest.raises(TimeoutError):
+        execute_research_code(
+            timeout_server.client(),
+            "input()",
+            execution_timeout=0.5,
+            _websocket_connect=FakeConnector(timeout=True),
+        )
+    assert len(delete_requests(timeout_server)) == 1
+
+    def input_builder(request, _):
+        return [
+            json.dumps(
+                message(
+                    request,
+                    "input_request",
+                    "stdin",
+                    {"prompt": "secret", "password": True},
+                )
+            )
+        ]
+
+    input_server = FakeResearchServer()
+    with pytest.raises(ApiError, match="stdin"):
+        execute_research_code(
+            input_server.client(), "input()", _websocket_connect=FakeConnector(input_builder)
+        )
+    assert len(delete_requests(input_server)) == 1
+
+
+def test_invalid_created_session_schema_is_cleaned_before_websocket():
+    server = FakeResearchServer()
+    server.session_create_payload = session_model("__jqcli_exec_placeholder.ipynb")
+    server.session_create_payload["kernel"]["name"] = 123
+    connector = FakeConnector()
+
+    with pytest.raises(ApiError):
+        execute_research_code(server.client(), "1", _websocket_connect=connector)
+
+    assert connector.calls == []
+    assert len(delete_requests(server)) == 1
+
+
+def test_create_redirect_is_not_followed_and_no_websocket_credentials_are_sent():
+    server = FakeResearchServer()
+
+    def redirecting_handler(request):
+        if request.url.path == "/user/tester/api/sessions" and request.method == "POST":
+            server.requests.append(request)
+            return httpx.Response(302, headers={"location": "/hub/login"})
+        return server.handler(request)
+
+    client = ApiClient(
+        "https://example.test",
+        cookie="main_session=private-cookie",
+        transport=httpx.MockTransport(redirecting_handler),
+    )
+    connector = FakeConnector()
+
+    with pytest.raises(NotAuthenticatedError):
+        execute_research_code(client, "1", _websocket_connect=connector)
+
+    assert connector.calls == []
+    assert delete_requests(server) == []
+
+
+def test_message_budget_is_cumulative_and_cleanup_still_runs(monkeypatch):
+    server = FakeResearchServer()
+    monkeypatch.setattr(execution_api, "_MAX_EXECUTION_MESSAGE_COUNT", 1)
+
+    with pytest.raises(ApiError, match="安全处理上限"):
+        execute_research_code(server.client(), "1", _websocket_connect=FakeConnector())
+
+    assert len(delete_requests(server)) == 1
+
+
+def test_notebook_message_budget_is_shared_across_cells(monkeypatch):
+    server = FakeResearchServer()
+    monkeypatch.setattr(execution_api, "_MAX_EXECUTION_MESSAGE_COUNT", 5)
+
+    with pytest.raises(ApiError, match="安全处理上限"):
+        run_research_notebook(
+            server.client(),
+            "folder/demo.ipynb",
+            cell_indexes=[0, 2],
+            _websocket_connect=FakeConnector(),
+        )
+
+    assert len(delete_requests(server)) == 1
+
+
+def test_non_finite_kernel_json_is_rejected_and_cleanup_still_runs():
+    def builder(request, _):
+        return [
+            json.dumps(
+                message(request, "status", "iopub", {"execution_state": float("nan")})
+            )
+        ]
+
+    server = FakeResearchServer()
+    with pytest.raises(ApiError, match="JSON"):
+        execute_research_code(server.client(), "1", _websocket_connect=FakeConnector(builder))
+    assert len(delete_requests(server)) == 1
+
+
+def test_cleanup_requires_documented_204_status():
+    server = FakeResearchServer()
+    server.delete_status = 200
+
+    with pytest.raises(ApiError, match="清理"):
+        execute_research_code(server.client(), "1", _websocket_connect=FakeConnector())
+
+
+def test_run_uses_one_bootstrap_synthetic_session_selected_cells_and_never_saves():
+    server = FakeResearchServer()
+    server.contents["content"]["metadata"]["kernelspec"] = {"name": "notebook-python"}
+
+    def builder(request, count):
+        return success_messages(request, execution_count=count)
+
+    connector = FakeConnector(builder)
+    result = run_research_notebook(
+        server.client(),
+        "folder/demo.ipynb",
+        cell_indexes=[2, 0],
+        execution_timeout=10,
+        _websocket_connect=connector,
+    )
+
+    assert result["status"] == "ok"
+    assert result["path"] == "folder/demo.ipynb"
+    assert result["total_code_cells"] == 2
+    assert result["selected_code_cells"] == 2
+    assert result["executed_cells"] == 2
+    assert [cell["cell_index"] for cell in result["cells"]] == [0, 2]
+    assert result["saved"] is False
+    assert [request["content"]["code"] for request in connector.socket.sent] == [
+        "value = 1\nvalue",
+        "value + 1",
+    ]
+    session_posts = [
+        request
+        for request in server.requests
+        if request.method == "POST" and request.url.path == "/user/tester/api/sessions"
+    ]
+    assert len(session_posts) == 1
+    posted_body = json.loads(session_posts[0].content)
+    posted_path = posted_body["path"]
+    assert re.fullmatch(r"folder/__jqcli_run_[0-9a-f]{32}\.ipynb", posted_path)
+    assert posted_path != "folder/demo.ipynb"
+    assert posted_body["kernel"] == {"name": "notebook-python"}
+    assert server.bootstrap_count == 1
+    assert len(delete_requests(server)) == 1
+    assert delete_requests(server)[0].url.path == "/user/tester/api/sessions/new-session"
+    assert not any(request.method == "PUT" for request in server.requests)
+    assert "new-session" not in json.dumps(result)
+    assert "new-kernel" not in json.dumps(result)
+
+
+@pytest.mark.parametrize("indexes", [[1], [99], [0, 0], [-1]])
+def test_run_rejects_invalid_cell_selection_before_remote_mutation(indexes):
+    server = FakeResearchServer()
+
+    with pytest.raises(UsageError):
+        run_research_notebook(server.client(), "folder/demo.ipynb", cell_indexes=indexes)
+
+    assert not any(
+        request.method == "POST" and request.url.path == "/user/tester/api/sessions"
+        for request in server.requests
+    )
+    assert delete_requests(server) == []
+
+
+def test_lost_session_post_is_recovered_only_by_synthetic_path_and_cleaned():
+    server = FakeResearchServer()
+    server.session_post_error = httpx.ReadTimeout
+
+    with pytest.raises(NetworkError):
+        run_research_notebook(
+            server.client(),
+            "folder/demo.ipynb",
+            cell_indexes=[0],
+            _websocket_connect=FakeConnector(),
+        )
+
+    assert len(server.sessions) == 1
+    assert re.fullmatch(r"folder/__jqcli_run_[0-9a-f]{32}\.ipynb", server.sessions[0]["path"])
+    assert len(delete_requests(server)) == 1
+    assert delete_requests(server)[0].url.path == "/user/tester/api/sessions/new-session"
+
+
+def test_lost_exec_session_post_is_recovered_and_cleaned():
+    server = FakeResearchServer()
+    server.session_post_error = httpx.ReadTimeout
+
+    with pytest.raises(NetworkError):
+        execute_research_code(server.client(), "1", _websocket_connect=FakeConnector())
+
+    assert len(server.sessions) == 1
+    assert re.fullmatch(r"__jqcli_exec_[0-9a-f]{32}\.ipynb", server.sessions[0]["path"])
+    assert len(delete_requests(server)) == 1
+    assert delete_requests(server)[0].url.path == "/user/tester/api/sessions/new-session"
+
+
+def test_synthetic_session_collision_fails_before_create_or_delete(monkeypatch):
+    server = FakeResearchServer()
+    server.sessions = [session_model("__jqcli_exec_fixed.ipynb", "user-session", "user-kernel")]
+    monkeypatch.setattr(
+        execution_api,
+        "_synthetic_session_path",
+        lambda *args, **kwargs: "__jqcli_exec_fixed.ipynb",
+    )
+
+    with pytest.raises(ApiError, match="冲突"):
+        execute_research_code(server.client(), "1", _websocket_connect=FakeConnector())
+
+    assert not any(
+        request.method == "POST" and request.url.path == "/user/tester/api/sessions"
+        for request in server.requests
+    )
+    assert delete_requests(server) == []
+
+
+@pytest.mark.parametrize("code", ["", " \t\r\n"])
+def test_execute_rejects_empty_code_before_bootstrap(code):
+    server = FakeResearchServer()
+
+    with pytest.raises(UsageError):
+        execute_research_code(server.client(), code, _websocket_connect=FakeConnector())
+
+    assert server.requests == []
+
+
+def test_invalid_list_and_binary_schemas_fail_closed():
+    server = FakeResearchServer()
+    server.kernels = {"not": "a list"}
+    with pytest.raises(ApiError):
+        list_research_kernels(server.client())
+
+    def malformed_binary(request, _):
+        return [b"\x00\x00\x00\x01\x00\x00\x00\xff"]
+
+    server = FakeResearchServer()
+    with pytest.raises(ApiError):
+        execute_research_code(
+            server.client(), "1", _websocket_connect=FakeConnector(malformed_binary)
+        )
+    assert len(delete_requests(server)) == 1

--- a/tests/test_commands/test_research.py
+++ b/tests/test_commands/test_research.py
@@ -1,0 +1,1147 @@
+import base64
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from click.testing import CliRunner
+
+from jqcli.cli import main
+from jqcli.errors import NotFoundError, UsageError
+
+
+class FakeClient:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+def command_prefix(tmp_path, *, json_output=True, token=None):
+    args = ["--config", str(tmp_path / "c.json"), "--cookie", "sid=abc"]
+    if token:
+        args.extend(["--token", token])
+    if json_output:
+        args.extend(["--format", "json"])
+    return args
+
+
+def test_research_requires_cookie_even_with_token(tmp_path):
+    result = CliRunner().invoke(
+        main,
+        ["--config", str(tmp_path / "c.json"), "--token", "tok", "--format", "json", "research", "ls"],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stderr)
+    assert payload["error"]["code"] == "not_authenticated"
+    assert "cookie" in payload["error"]["message"]
+
+
+def test_research_make_client_uses_cookie_without_bearer_token(monkeypatch, tmp_path):
+    captured = {}
+
+    class CapturingClient(FakeClient):
+        def __init__(self, api_base, **kwargs):
+            super().__init__()
+            captured["api_base"] = api_base
+            captured.update(kwargs)
+
+    monkeypatch.setattr("jqcli.commands.research.ApiClient", CapturingClient)
+    monkeypatch.setattr("jqcli.commands.research.list_research_items", lambda client, path="": {"items": []})
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path, token="tok") + ["--api-base", "https://example.test", "research", "ls"],
+    )
+
+    assert result.exit_code == 0
+    assert captured["api_base"] == "https://example.test"
+    assert captured["cookie"] == "sid=abc"
+    assert "token" not in captured
+
+
+def test_research_ls_json_forwards_path_and_closes(monkeypatch, tmp_path):
+    client = FakeClient()
+    captured = {}
+    payload = {"path": "目录 A", "items": [{"name": "分析.ipynb", "type": "notebook"}]}
+    monkeypatch.setattr("jqcli.commands.research.make_client", lambda app: client)
+
+    def fake_list(received_client, *, path=""):
+        captured["client"] = received_client
+        captured["path"] = path
+        return payload
+
+    monkeypatch.setattr("jqcli.commands.research.list_research_items", fake_list)
+
+    result = CliRunner().invoke(main, command_prefix(tmp_path) + ["research", "ls", "目录 A"])
+
+    assert result.exit_code == 0
+    assert captured == {"client": client, "path": "目录 A"}
+    assert json.loads(result.output) == payload
+    assert client.closed is True
+
+
+def test_research_ls_table_has_expected_columns(monkeypatch, tmp_path):
+    client = FakeClient()
+    monkeypatch.setattr("jqcli.commands.research.make_client", lambda app: client)
+    monkeypatch.setattr(
+        "jqcli.commands.research.list_research_items",
+        lambda received_client, path="": {
+            "items": [
+                {
+                    "name": "分析.ipynb",
+                    "type": "notebook",
+                    "size": 42,
+                    "last_modified": "2026-08-14T12:00:00Z",
+                    "writable": True,
+                }
+            ]
+        },
+    )
+
+    result = CliRunner().invoke(main, command_prefix(tmp_path, json_output=False) + ["research", "ls"])
+
+    assert result.exit_code == 0
+    for heading in ("名称", "类型", "大小", "最近修改", "可写"):
+        assert heading in result.output
+    assert "分析.ipynb" in result.output
+    assert client.closed is True
+
+
+def test_research_ls_closes_client_when_api_fails(monkeypatch, tmp_path):
+    client = FakeClient()
+    monkeypatch.setattr("jqcli.commands.research.make_client", lambda app: client)
+
+    def fail(received_client, *, path=""):
+        raise UsageError("bad path")
+
+    monkeypatch.setattr("jqcli.commands.research.list_research_items", fail)
+
+    result = CliRunner().invoke(main, command_prefix(tmp_path) + ["research", "ls"])
+
+    assert result.exit_code == 3
+    assert client.closed is True
+
+
+def test_research_show_forwards_content_flag_and_closes(monkeypatch, tmp_path):
+    client = FakeClient()
+    captured = {}
+    payload = {"path": "分析.ipynb", "type": "notebook", "format": "json", "content": {"cells": []}}
+    monkeypatch.setattr("jqcli.commands.research.make_client", lambda app: client)
+
+    def fake_get(received_client, path, *, include_content=False):
+        captured.update(client=received_client, path=path, include_content=include_content)
+        return payload
+
+    monkeypatch.setattr("jqcli.commands.research.get_research_item", fake_get)
+
+    result = CliRunner().invoke(main, command_prefix(tmp_path) + ["research", "show", "分析.ipynb", "--content"])
+
+    assert result.exit_code == 0
+    assert captured == {"client": client, "path": "分析.ipynb", "include_content": True}
+    assert json.loads(result.output) == payload
+    assert client.closed is True
+
+
+@pytest.mark.parametrize(
+    ("content_format", "content", "expected"),
+    [
+        ("text", "print('你好')", "print('你好')"),
+        ("json", {"cells": []}, '"cells": []'),
+        ("base64", "AP8=", "AP8="),
+    ],
+)
+def test_research_show_renders_content_in_table_mode(
+    monkeypatch, tmp_path, content_format, content, expected
+):
+    client = FakeClient()
+    monkeypatch.setattr("jqcli.commands.research.make_client", lambda app: client)
+    monkeypatch.setattr(
+        "jqcli.commands.research.get_research_item",
+        lambda received_client, path, include_content=False: {
+            "path": path,
+            "name": "item",
+            "type": "file",
+            "format": content_format,
+            "content": content,
+        },
+    )
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path, json_output=False) + ["research", "show", "item", "--content"],
+    )
+
+    assert result.exit_code == 0
+    assert "路径: item" in result.output
+    assert "内容:" in result.output
+    assert expected in result.output
+    assert client.closed is True
+
+
+def test_research_download_text(monkeypatch, tmp_path):
+    client = FakeClient()
+    output = tmp_path / "nested" / "hello.txt"
+    monkeypatch.setattr("jqcli.commands.research.make_client", lambda app: client)
+    monkeypatch.setattr(
+        "jqcli.commands.research.get_research_item",
+        lambda received_client, path, include_content=False: {
+            "path": path,
+            "name": "hello.txt",
+            "type": "file",
+            "format": "text",
+            "content": "你好\n",
+        },
+    )
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path) + ["research", "download", "folder/hello.txt", "--output", str(output)],
+    )
+
+    assert result.exit_code == 0
+    assert output.read_bytes() == "你好\n".encode("utf-8")
+    assert json.loads(result.output) == {
+        "path": "folder/hello.txt",
+        "output": str(output),
+        "bytes": len("你好\n".encode("utf-8")),
+    }
+    assert client.closed is True
+
+
+def test_research_download_base64(monkeypatch, tmp_path):
+    client = FakeClient()
+    output = tmp_path / "data.bin"
+    raw = b"\x00\xff\x10"
+    monkeypatch.setattr("jqcli.commands.research.make_client", lambda app: client)
+    monkeypatch.setattr(
+        "jqcli.commands.research.get_research_item",
+        lambda received_client, path, include_content=False: {
+            "path": path,
+            "name": "data.bin",
+            "type": "file",
+            "format": "base64",
+            "content": base64.b64encode(raw).decode("ascii"),
+        },
+    )
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path) + ["research", "download", "data.bin", "-o", str(output)],
+    )
+
+    assert result.exit_code == 0
+    assert output.read_bytes() == raw
+    assert json.loads(result.output)["bytes"] == len(raw)
+    assert client.closed is True
+
+
+def test_research_download_notebook_json_uses_safe_default_name(monkeypatch, tmp_path):
+    client = FakeClient()
+    notebook = {"cells": [{"cell_type": "markdown", "source": ["# 你好"]}], "metadata": {}}
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("jqcli.commands.research.make_client", lambda app: client)
+    monkeypatch.setattr(
+        "jqcli.commands.research.get_research_item",
+        lambda received_client, path, include_content=False: {
+            "path": "folder/note.ipynb",
+            "name": "../note.ipynb",
+            "type": "notebook",
+            "format": "json",
+            "content": notebook,
+        },
+    )
+
+    result = CliRunner().invoke(main, command_prefix(tmp_path) + ["research", "download", "folder/note.ipynb"])
+
+    assert result.exit_code == 0
+    output = tmp_path / "note.ipynb"
+    assert json.loads(output.read_text(encoding="utf-8")) == notebook
+    assert output.read_bytes().endswith(b"\n")
+    assert json.loads(result.output)["output"] == "note.ipynb"
+    assert client.closed is True
+
+
+def test_research_download_refuses_existing_output_unless_forced(monkeypatch, tmp_path):
+    client = FakeClient()
+    output = tmp_path / "hello.txt"
+    output.write_text("old", encoding="utf-8")
+    monkeypatch.setattr("jqcli.commands.research.make_client", lambda app: client)
+    monkeypatch.setattr(
+        "jqcli.commands.research.get_research_item",
+        lambda received_client, path, include_content=False: {
+            "path": path,
+            "name": "hello.txt",
+            "type": "file",
+            "format": "text",
+            "content": "new",
+        },
+    )
+    args = command_prefix(tmp_path) + ["research", "download", "hello.txt", "-o", str(output)]
+
+    refused = CliRunner().invoke(main, args)
+    forced = CliRunner().invoke(main, args + ["--force"])
+
+    assert refused.exit_code == 6
+    assert json.loads(refused.stderr)["error"]["code"] == "file_error"
+    assert forced.exit_code == 0
+    assert output.read_text(encoding="utf-8") == "new"
+    assert client.closed is True
+
+
+def test_research_download_rejects_directory(monkeypatch, tmp_path):
+    client = FakeClient()
+    monkeypatch.setattr("jqcli.commands.research.make_client", lambda app: client)
+    monkeypatch.setattr(
+        "jqcli.commands.research.get_research_item",
+        lambda received_client, path, include_content=False: {
+            "path": path,
+            "name": "folder",
+            "type": "directory",
+            "format": "json",
+            "content": [],
+        },
+    )
+
+    result = CliRunner().invoke(main, command_prefix(tmp_path) + ["research", "download", "folder"])
+
+    assert result.exit_code == 3
+    assert json.loads(result.stderr)["error"]["code"] == "usage_error"
+    assert client.closed is True
+
+
+@pytest.mark.parametrize(
+    ("content_format", "content", "message"),
+    [
+        ("base64", "%%%", "base64"),
+        ("json", "{bad", "JSON"),
+        ("text", {"not": "text"}, "文本"),
+    ],
+)
+def test_research_download_rejects_bad_content(monkeypatch, tmp_path, content_format, content, message):
+    client = FakeClient()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("jqcli.commands.research.make_client", lambda app: client)
+    monkeypatch.setattr(
+        "jqcli.commands.research.get_research_item",
+        lambda received_client, path, include_content=False: {
+            "path": path,
+            "name": "bad.dat",
+            "type": "file",
+            "format": content_format,
+            "content": content,
+        },
+    )
+
+    result = CliRunner().invoke(main, command_prefix(tmp_path) + ["research", "download", "bad.dat"])
+
+    assert result.exit_code == 6
+    payload = json.loads(result.stderr)
+    assert payload["error"]["code"] == "file_error"
+    assert message in payload["error"]["message"]
+    assert client.closed is True
+    assert not (tmp_path / "bad.dat").exists()
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        ["upload", "{local}"],
+        ["mkdir", "folder"],
+        ["mv", "source", "destination"],
+        ["rm", "item"],
+    ],
+)
+def test_research_writes_require_yes_without_calling_api(monkeypatch, tmp_path, command):
+    local = tmp_path / "upload.txt"
+    local.write_text("data", encoding="utf-8")
+    args = [str(local) if value == "{local}" else value for value in command]
+
+    def unexpected_client(app):
+        raise AssertionError("write command must not create a client before confirmation")
+
+    monkeypatch.setattr("jqcli.commands.research.make_client", unexpected_client)
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path) + ["--non-interactive", "research"] + args,
+    )
+
+    assert result.exit_code == 7
+    assert json.loads(result.stderr)["error"]["code"] == "confirmation_required"
+
+
+def test_research_json_write_requires_yes_without_printing_prompt(monkeypatch, tmp_path):
+    def unexpected_client(app):
+        raise AssertionError("JSON write must fail before creating a client")
+
+    monkeypatch.setattr("jqcli.commands.research.make_client", unexpected_client)
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path) + ["research", "mkdir", "folder"],
+    )
+
+    assert result.exit_code == 7
+    assert "确认在研究平台" not in result.output
+    assert json.loads(result.stderr)["error"]["code"] == "confirmation_required"
+
+
+def test_research_upload_text_uses_default_remote_name(monkeypatch, tmp_path):
+    client = FakeClient()
+    local = tmp_path / "你好.py"
+    local.write_bytes("print('你好')\n".encode("utf-8"))
+    captured = {}
+    monkeypatch.setattr("jqcli.commands.research.make_client", lambda app: client)
+
+    def missing(received_client, path, include_content=False):
+        captured["preflight"] = (received_client, path, include_content)
+        raise NotFoundError("missing")
+
+    def fake_save(received_client, path, **kwargs):
+        captured["save"] = (received_client, path, kwargs)
+        return {"path": path, "type": kwargs["item_type"], "format": kwargs["content_format"]}
+
+    monkeypatch.setattr("jqcli.commands.research.get_research_item", missing)
+    monkeypatch.setattr("jqcli.commands.research.save_research_item", fake_save)
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path) + ["--non-interactive", "research", "upload", str(local), "--yes"],
+    )
+
+    assert result.exit_code == 0
+    assert captured["preflight"] == (client, "你好.py", False)
+    received_client, path, kwargs = captured["save"]
+    assert received_client is client
+    assert path == "你好.py"
+    assert kwargs == {
+        "content": "print('你好')\n",
+        "item_type": "file",
+        "content_format": "text",
+    }
+    assert json.loads(result.output)["path"] == "你好.py"
+    assert client.closed is True
+
+
+def test_research_upload_notebook_json_with_force(monkeypatch, tmp_path):
+    client = FakeClient()
+    local = tmp_path / "note.ipynb"
+    notebook = {"cells": [], "metadata": {"language_info": {"name": "python"}}, "nbformat": 4}
+    local.write_text(json.dumps(notebook, ensure_ascii=False), encoding="utf-8")
+    captured = {}
+    monkeypatch.setattr("jqcli.commands.research.make_client", lambda app: client)
+    monkeypatch.setattr(
+        "jqcli.commands.research.get_research_item",
+        lambda received_client, path, include_content=False: {"path": path, "type": "notebook"},
+    )
+
+    def fake_save(received_client, path, **kwargs):
+        captured.update(client=received_client, path=path, kwargs=kwargs)
+        return {"path": path, "type": "notebook", "format": "json"}
+
+    monkeypatch.setattr("jqcli.commands.research.save_research_item", fake_save)
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path)
+        + [
+            "--non-interactive",
+            "research",
+            "upload",
+            str(local),
+            "folder/note.ipynb",
+            "--force",
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured == {
+        "client": client,
+        "path": "folder/note.ipynb",
+        "kwargs": {"content": notebook, "item_type": "notebook", "content_format": "json"},
+    }
+    assert client.closed is True
+
+
+def test_research_upload_binary_as_base64(monkeypatch, tmp_path):
+    client = FakeClient()
+    local = tmp_path / "data.bin"
+    raw = b"\x00\x01\x02"
+    local.write_bytes(raw)
+    captured = {}
+    monkeypatch.setattr("jqcli.commands.research.make_client", lambda app: client)
+    monkeypatch.setattr(
+        "jqcli.commands.research.get_research_item",
+        lambda received_client, path, include_content=False: (_ for _ in ()).throw(NotFoundError("missing")),
+    )
+
+    def fake_save(received_client, path, **kwargs):
+        captured.update(path=path, kwargs=kwargs)
+        return {"path": path, "type": "file", "format": "base64"}
+
+    monkeypatch.setattr("jqcli.commands.research.save_research_item", fake_save)
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path) + ["--non-interactive", "research", "upload", str(local), "--yes"],
+    )
+
+    assert result.exit_code == 0
+    assert captured == {
+        "path": "data.bin",
+        "kwargs": {
+            "content": base64.b64encode(raw).decode("ascii"),
+            "item_type": "file",
+            "content_format": "base64",
+        },
+    }
+    assert client.closed is True
+
+
+def test_research_upload_refuses_remote_overwrite_without_force(monkeypatch, tmp_path):
+    client = FakeClient()
+    local = tmp_path / "data.txt"
+    local.write_text("new", encoding="utf-8")
+    saved = []
+    monkeypatch.setattr("jqcli.commands.research.make_client", lambda app: client)
+    monkeypatch.setattr(
+        "jqcli.commands.research.get_research_item",
+        lambda received_client, path, include_content=False: {"path": path, "type": "file"},
+    )
+    monkeypatch.setattr("jqcli.commands.research.save_research_item", lambda *args, **kwargs: saved.append((args, kwargs)))
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path)
+        + ["--non-interactive", "research", "upload", str(local), "remote.txt", "--yes"],
+    )
+
+    assert result.exit_code == 6
+    assert json.loads(result.stderr)["error"]["code"] == "file_error"
+    assert "--force" in json.loads(result.stderr)["error"]["message"]
+    assert saved == []
+    assert client.closed is True
+
+
+def test_research_upload_rejects_files_larger_than_25_mib_before_api(monkeypatch, tmp_path):
+    local = tmp_path / "large.bin"
+    local.write_bytes(b"small fixture")
+    original_stat = Path.stat
+
+    def fake_stat(path, *args, **kwargs):
+        if path == local:
+            return SimpleNamespace(st_size=25 * 1024 * 1024 + 1)
+        return original_stat(path, *args, **kwargs)
+
+    def unexpected_client(app):
+        raise AssertionError("oversized upload must be rejected before API access")
+
+    monkeypatch.setattr(Path, "stat", fake_stat)
+    monkeypatch.setattr("jqcli.commands.research.make_client", unexpected_client)
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path) + ["--non-interactive", "research", "upload", str(local), "--yes"],
+    )
+
+    assert result.exit_code == 6
+    payload = json.loads(result.stderr)
+    assert payload["error"]["code"] == "file_error"
+    assert "25 MiB" in payload["error"]["message"]
+
+
+def test_research_mkdir_json_and_close(monkeypatch, tmp_path):
+    client = FakeClient()
+    captured = {}
+    monkeypatch.setattr("jqcli.commands.research.make_client", lambda app: client)
+
+    def fake_mkdir(received_client, path):
+        captured.update(client=received_client, path=path)
+        return {"path": path, "type": "directory"}
+
+    monkeypatch.setattr("jqcli.commands.research.create_research_directory", fake_mkdir)
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path) + ["--non-interactive", "research", "mkdir", "folder", "--yes"],
+    )
+
+    assert result.exit_code == 0
+    assert captured == {"client": client, "path": "folder"}
+    assert json.loads(result.output) == {"path": "folder", "type": "directory"}
+    assert client.closed is True
+
+
+def test_research_mv_json_and_close(monkeypatch, tmp_path):
+    client = FakeClient()
+    captured = {}
+    monkeypatch.setattr("jqcli.commands.research.make_client", lambda app: client)
+
+    def fake_move(received_client, source, destination):
+        captured.update(client=received_client, source=source, destination=destination)
+        return {"path": destination, "type": "file"}
+
+    monkeypatch.setattr("jqcli.commands.research.move_research_item", fake_move)
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path)
+        + ["--non-interactive", "research", "mv", "old.txt", "folder/new.txt", "--yes"],
+    )
+
+    assert result.exit_code == 0
+    assert captured == {"client": client, "source": "old.txt", "destination": "folder/new.txt"}
+    assert json.loads(result.output)["path"] == "folder/new.txt"
+    assert client.closed is True
+
+
+def test_research_rm_wraps_empty_response(monkeypatch, tmp_path):
+    client = FakeClient()
+    captured = {}
+    monkeypatch.setattr("jqcli.commands.research.make_client", lambda app: client)
+
+    def fake_delete(received_client, path):
+        captured.update(client=received_client, path=path)
+        return None
+
+    monkeypatch.setattr("jqcli.commands.research.delete_research_item", fake_delete)
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path) + ["--non-interactive", "research", "rm", "old.txt", "--yes"],
+    )
+
+    assert result.exit_code == 0
+    assert captured == {"client": client, "path": "old.txt"}
+    assert json.loads(result.output) == {"ok": True, "path": "old.txt"}
+    assert client.closed is True
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["mkdir", "/", "--yes"],
+        ["mv", "/", "destination", "--yes"],
+        ["mv", "source", "//", "--yes"],
+        ["rm", ".", "--yes"],
+    ],
+)
+def test_research_writes_reject_root_paths(monkeypatch, tmp_path, args):
+    def unexpected_client(app):
+        raise AssertionError("root path must be rejected before API access")
+
+    monkeypatch.setattr("jqcli.commands.research.make_client", unexpected_client)
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path) + ["--non-interactive", "research"] + args,
+    )
+
+    assert result.exit_code == 3
+    assert json.loads(result.stderr)["error"]["code"] == "usage_error"
+
+
+def test_research_write_rejects_unsafe_path_before_confirmation(monkeypatch, tmp_path):
+    def unexpected_client(app):
+        raise AssertionError("unsafe path must be rejected before API access")
+
+    monkeypatch.setattr("jqcli.commands.research.make_client", unexpected_client)
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path, json_output=False) + ["research", "rm", "folder/../item"],
+    )
+
+    assert result.exit_code == 3
+    assert "确认删除" not in result.output
+    assert "无效组件" in result.output
+
+
+@pytest.mark.parametrize(
+    ("command", "api_name", "payload"),
+    [
+        (
+            "kernelspecs",
+            "list_research_kernelspecs",
+            {
+                "default": "python3",
+                "items": [{"name": "python3", "display_name": "Python 3", "language": "python"}],
+                "total": 1,
+            },
+        ),
+        (
+            "kernels",
+            "list_research_kernels",
+            {"items": [{"id": "k1", "name": "python3", "execution_state": "idle"}], "total": 1},
+        ),
+        (
+            "sessions",
+            "list_research_sessions",
+            {
+                "items": [
+                    {
+                        "id": "s1",
+                        "path": "note.ipynb",
+                        "type": "notebook",
+                        "kernel": {"name": "python3", "execution_state": "idle"},
+                    }
+                ],
+                "total": 1,
+            },
+        ),
+    ],
+)
+def test_research_runtime_lists_are_read_only_json_and_close(
+    monkeypatch, tmp_path, command, api_name, payload
+):
+    client = FakeClient()
+    received = []
+    monkeypatch.setattr("jqcli.commands.research.make_client", lambda app: client)
+
+    def fake_list(received_client):
+        received.append(received_client)
+        return payload
+
+    monkeypatch.setattr(f"jqcli.commands.research.{api_name}", fake_list)
+
+    result = CliRunner().invoke(main, command_prefix(tmp_path) + ["research", command])
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == payload
+    assert received == [client]
+    assert client.closed is True
+
+
+def test_research_kernelspecs_table_marks_default(monkeypatch, tmp_path):
+    client = FakeClient()
+    monkeypatch.setattr("jqcli.commands.research.make_client", lambda app: client)
+    monkeypatch.setattr(
+        "jqcli.commands.research.list_research_kernelspecs",
+        lambda received_client: {
+            "default": "python3",
+            "items": [
+                {
+                    "name": "python3",
+                    "display_name": "Python 3",
+                    "language": "python",
+                    "interrupt_mode": "signal",
+                }
+            ],
+            "total": 1,
+        },
+    )
+
+    result = CliRunner().invoke(
+        main, command_prefix(tmp_path, json_output=False) + ["research", "kernelspecs"]
+    )
+
+    assert result.exit_code == 0
+    for expected in ("名称", "显示名称", "Python 3", "python", "signal", "是"):
+        assert expected in result.output
+    assert client.closed is True
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["exec", "--yes"],
+        ["exec", "--file", "code.py", "--code-stdin", "--yes"],
+    ],
+)
+def test_research_exec_requires_exactly_one_code_source_before_api(monkeypatch, tmp_path, args):
+    monkeypatch.setattr(
+        "jqcli.commands.research.make_client",
+        lambda app: (_ for _ in ()).throw(AssertionError("invalid source selection must not call API")),
+    )
+
+    result = CliRunner().invoke(main, command_prefix(tmp_path) + ["research"] + args)
+
+    assert result.exit_code == 3
+    assert json.loads(result.stderr)["error"]["code"] == "usage_error"
+
+
+def test_research_exec_confirms_before_reading_file_or_calling_api(monkeypatch, tmp_path):
+    missing = tmp_path / "missing.py"
+    monkeypatch.setattr(
+        "jqcli.commands.research.make_client",
+        lambda app: (_ for _ in ()).throw(AssertionError("unconfirmed execution must not call API")),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path) + ["research", "exec", "--file", str(missing)],
+    )
+
+    assert result.exit_code == 7
+    assert json.loads(result.stderr)["error"]["code"] == "confirmation_required"
+
+
+def test_research_exec_table_mode_also_requires_explicit_yes_before_file_read(monkeypatch, tmp_path):
+    missing = tmp_path / "missing.py"
+    monkeypatch.setattr(
+        "jqcli.commands.research.make_client",
+        lambda app: (_ for _ in ()).throw(AssertionError("unconfirmed execution must not call API")),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path, json_output=False)
+        + ["research", "exec", "--file", str(missing)],
+    )
+
+    assert result.exit_code == 7
+    assert "必须显式传入 --yes" in result.output
+    assert "无法读取执行代码" not in result.output
+
+
+def test_research_exec_code_stdin_always_requires_explicit_yes(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "jqcli.commands.research.make_client",
+        lambda app: (_ for _ in ()).throw(AssertionError("unconfirmed stdin must not call API")),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path, json_output=False) + ["research", "exec", "--code-stdin"],
+        input="print('not consumed')\n",
+    )
+
+    assert result.exit_code == 7
+    assert "必须显式传入 --yes" in result.output
+
+
+def test_research_exec_file_forwards_options_and_closes(monkeypatch, tmp_path):
+    client = FakeClient()
+    source = tmp_path / "hello.py"
+    source.write_bytes("print('你好')\n".encode("utf-8"))
+    captured = {}
+    monkeypatch.setattr("jqcli.commands.research.make_client", lambda app: client)
+
+    def fake_execute(received_client, code, **kwargs):
+        captured.update(client=received_client, code=code, kwargs=kwargs)
+        return {"status": "ok", "execution_count": 1, "outputs": []}
+
+    monkeypatch.setattr("jqcli.commands.research.execute_research_code", fake_execute)
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path)
+        + [
+            "research",
+            "exec",
+            "--file",
+            str(source),
+            "--kernel",
+            "python3",
+            "--execution-timeout",
+            "9.5",
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["client"] is client
+    assert captured["code"] == "print('你好')\n"
+    assert captured["kwargs"] == {"kernel_name": "python3", "execution_timeout": 9.5, "on_event": None}
+    assert json.loads(result.output)["status"] == "ok"
+    assert client.closed is True
+
+
+@pytest.mark.parametrize("content", [b"", b"  \n\t", b"\xff\xfe"])
+def test_research_exec_rejects_empty_or_non_utf8_file_before_api(monkeypatch, tmp_path, content):
+    source = tmp_path / "bad.py"
+    source.write_bytes(content)
+    monkeypatch.setattr(
+        "jqcli.commands.research.make_client",
+        lambda app: (_ for _ in ()).throw(AssertionError("bad code must not call API")),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path) + ["research", "exec", "--file", str(source), "--yes"],
+    )
+
+    assert result.exit_code == 6
+    assert json.loads(result.stderr)["error"]["code"] == "file_error"
+
+
+@pytest.mark.parametrize("command", ["exec", "run"])
+@pytest.mark.parametrize("timeout", ["0", "-1", "nan", "inf"])
+def test_research_execution_rejects_invalid_timeout_before_api(
+    monkeypatch, tmp_path, command, timeout
+):
+    monkeypatch.setattr(
+        "jqcli.commands.research.make_client",
+        lambda app: (_ for _ in ()).throw(AssertionError("bad timeout must not call API")),
+    )
+    args = ["research", command]
+    if command == "exec":
+        args += ["--code-stdin"]
+    else:
+        args += ["note.ipynb"]
+    args += ["--execution-timeout", timeout, "--yes"]
+
+    result = CliRunner().invoke(main, command_prefix(tmp_path) + args, input="print(1)\n")
+
+    assert result.exit_code == 3
+    assert json.loads(result.stderr)["error"]["code"] == "usage_error"
+
+
+def test_research_exec_stream_requires_json_before_reading_or_api(monkeypatch, tmp_path):
+    source = tmp_path / "code.py"
+    source.write_text("print(1)", encoding="utf-8")
+    monkeypatch.setattr(
+        "jqcli.commands.research.make_client",
+        lambda app: (_ for _ in ()).throw(AssertionError("invalid stream mode must not call API")),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path, json_output=False)
+        + ["research", "exec", "--file", str(source), "--stream", "--yes"],
+    )
+
+    assert result.exit_code == 3
+    assert "--stream 仅支持 --format json" in result.output
+
+
+def test_research_exec_stream_emits_events_and_final_done(monkeypatch, tmp_path):
+    client = FakeClient()
+    monkeypatch.setattr("jqcli.commands.research.make_client", lambda app: client)
+
+    def fake_execute(received_client, code, **kwargs):
+        kwargs["on_event"]({"event": "status", "state": "busy"})
+        kwargs["on_event"](
+            {"event": "output", "output": {"output_type": "stream", "name": "stdout", "text": "ok\n"}}
+        )
+        return {
+            "status": "ok",
+            "execution_count": 1,
+            "outputs": [{"output_type": "stream", "name": "stdout", "text": "ok\n"}],
+        }
+
+    monkeypatch.setattr("jqcli.commands.research.execute_research_code", fake_execute)
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path)
+        + ["research", "exec", "--code-stdin", "--stream", "--yes"],
+        input="print('ok')\n",
+    )
+
+    assert result.exit_code == 0
+    lines = [json.loads(line) for line in result.output.splitlines()]
+    assert [line.get("event") or line.get("type") for line in lines] == ["status", "output", "done"]
+    assert lines[-1]["result"]["status"] == "ok"
+    assert client.closed is True
+
+
+def test_research_run_stream_emits_cell_events_and_final_done(monkeypatch, tmp_path):
+    client = FakeClient()
+    monkeypatch.setattr("jqcli.commands.research.make_client", lambda app: client)
+
+    def fake_run(received_client, path, **kwargs):
+        kwargs["on_event"]({"cell_index": 2, "event": "status", "state": "busy"})
+        return {
+            "status": "ok",
+            "path": path,
+            "total_code_cells": 1,
+            "selected_code_cells": 1,
+            "executed_cells": 1,
+            "cells": [],
+            "saved": False,
+        }
+
+    monkeypatch.setattr("jqcli.commands.research.run_research_notebook", fake_run)
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path)
+        + ["research", "run", "note.ipynb", "--cell", "2", "--stream", "--yes"],
+    )
+
+    assert result.exit_code == 0
+    lines = [json.loads(line) for line in result.output.splitlines()]
+    assert [line["event"] for line in lines] == ["status", "done"]
+    assert lines[0]["cell_index"] == 2
+    assert lines[-1]["result"]["saved"] is False
+    assert client.closed is True
+
+
+def test_research_exec_closes_client_when_api_fails(monkeypatch, tmp_path):
+    client = FakeClient()
+    source = tmp_path / "code.py"
+    source.write_bytes(b"print(1)\n")
+    monkeypatch.setattr("jqcli.commands.research.make_client", lambda app: client)
+    monkeypatch.setattr(
+        "jqcli.commands.research.execute_research_code",
+        lambda received_client, code, **kwargs: (_ for _ in ()).throw(UsageError("remote failed")),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path) + ["research", "exec", "--file", str(source), "--yes"],
+    )
+
+    assert result.exit_code == 3
+    assert json.loads(result.stderr)["error"]["code"] == "usage_error"
+    assert client.closed is True
+
+
+def test_research_exec_table_only_renders_safe_plain_text_summary(monkeypatch, tmp_path):
+    client = FakeClient()
+    source = tmp_path / "code.py"
+    source.write_text("1", encoding="utf-8")
+    monkeypatch.setattr("jqcli.commands.research.make_client", lambda app: client)
+    monkeypatch.setattr(
+        "jqcli.commands.research.execute_research_code",
+        lambda received_client, code, **kwargs: {
+            "status": "error",
+            "execution_count": 3,
+            "outputs": [
+                {"output_type": "stream", "name": "stdout", "text": "safe\x1b[2J\n"},
+                {
+                    "output_type": "display_data",
+                    "data": {
+                        "text/plain": "plain value",
+                        "text/html": "<script>html-secret</script>",
+                        "application/javascript": "js-secret",
+                    },
+                    "metadata": {},
+                },
+                {
+                    "output_type": "error",
+                    "ename": "ValueError",
+                    "evalue": "bad",
+                    "traceback": ["traceback-secret"],
+                },
+            ],
+        },
+    )
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path, json_output=False)
+        + ["research", "exec", "--file", str(source), "--yes"],
+    )
+
+    assert result.exit_code == 0
+    for expected in ("状态: error", "safe", "plain value", "ValueError: bad"):
+        assert expected in result.output
+    for forbidden in ("\x1b", "html-secret", "js-secret", "traceback-secret"):
+        assert forbidden not in result.output
+    assert client.closed is True
+
+
+def test_research_run_normalizes_path_forwards_cells_and_closes(monkeypatch, tmp_path):
+    client = FakeClient()
+    captured = {}
+    monkeypatch.setattr("jqcli.commands.research.make_client", lambda app: client)
+
+    def fake_run(received_client, path, **kwargs):
+        captured.update(client=received_client, path=path, kwargs=kwargs)
+        return {
+            "status": "ok",
+            "path": path,
+            "total_code_cells": 2,
+            "executed_cells": 2,
+            "cells": [],
+            "saved": False,
+        }
+
+    monkeypatch.setattr("jqcli.commands.research.run_research_notebook", fake_run)
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path)
+        + [
+            "research",
+            "run",
+            "/folder/note.ipynb",
+            "--cell",
+            "0",
+            "--cell",
+            "2",
+            "--kernel",
+            "python3",
+            "--execution-timeout",
+            "15",
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured == {
+        "client": client,
+        "path": "folder/note.ipynb",
+        "kwargs": {
+            "cell_indexes": [0, 2],
+            "kernel_name": "python3",
+            "execution_timeout": 15.0,
+            "on_event": None,
+        },
+    }
+    assert json.loads(result.output)["saved"] is False
+    assert client.closed is True
+
+
+@pytest.mark.parametrize("cells", [["--cell", "-1"], ["--cell", "1", "--cell", "1"]])
+def test_research_run_rejects_invalid_cell_selection_before_api(monkeypatch, tmp_path, cells):
+    monkeypatch.setattr(
+        "jqcli.commands.research.make_client",
+        lambda app: (_ for _ in ()).throw(AssertionError("bad cells must not call API")),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path) + ["research", "run", "note.ipynb"] + cells + ["--yes"],
+    )
+
+    assert result.exit_code == 3
+    assert json.loads(result.stderr)["error"]["code"] == "usage_error"
+
+
+def test_research_run_requires_confirmation_before_api(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "jqcli.commands.research.make_client",
+        lambda app: (_ for _ in ()).throw(AssertionError("unconfirmed run must not call API")),
+    )
+
+    result = CliRunner().invoke(
+        main, command_prefix(tmp_path) + ["research", "run", "note.ipynb"]
+    )
+
+    assert result.exit_code == 7
+    assert json.loads(result.stderr)["error"]["code"] == "confirmation_required"
+
+
+def test_research_run_table_mode_also_requires_explicit_yes(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "jqcli.commands.research.make_client",
+        lambda app: (_ for _ in ()).throw(AssertionError("unconfirmed run must not call API")),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        command_prefix(tmp_path, json_output=False) + ["research", "run", "note.ipynb"],
+    )
+
+    assert result.exit_code == 7
+    assert "必须显式传入 --yes" in result.output
+
+
+def test_research_execution_kernel_help_matches_default_selection():
+    runner = CliRunner()
+
+    exec_help = runner.invoke(main, ["research", "exec", "--help"])
+    run_help = runner.invoke(main, ["research", "run", "--help"])
+
+    assert exec_help.exit_code == 0
+    assert "默认使用平台默认值" in exec_help.output
+    assert "Notebook 元数据" not in exec_help.output
+    assert run_help.exit_code == 0
+    assert "默认使用 Notebook 元数据或平台默认值" in run_help.output


### PR DESCRIPTION
## Summary

- add authenticated JoinQuant Research workspace access through the JupyterHub SSO and Contents APIs
- add `research ls/show/download/upload/mkdir/mv/rm` with path validation, overwrite protection, XSRF handling, and explicit confirmation for remote writes
- add kernel/session discovery plus isolated `research exec` and `research run` with JSONL streaming, output limits, timeouts, and guaranteed temporary-session cleanup
- harden cookie scoping and same-origin redirect handling in the shared HTTP client
- package all jqcli submodules and Web assets, add the WebSocket dependency, and update README, design notes, progress, and the jqcli skill

## Why

The existing CLI only covered strategy, backtest, and community endpoints. JoinQuant Research is a separate JupyterHub-backed service, so strategy file APIs and the existing JSON request path could not safely list research files or execute notebooks.

This adds a dedicated Research client while preserving existing strategy and backtest commands.

## Safety and compatibility

- existing commands and output contracts remain backward compatible
- research file writes require confirmation; upload does not overwrite unless `--force` is supplied
- remote execution always requires `--yes`, creates an exclusive high-entropy temporary session/kernel, never reuses existing runtimes, and cleans up in `finally`
- `research run` never saves outputs back to the remote Notebook
- SSO credentials, cookies, Authorization headers, XSRF tokens, and WebSocket handshakes are constrained to the expected same origin
- live discovery was read-only; no real research file write or deletion was performed

## Validation

- `.venv/Scripts/python.exe -m pytest -q` — 270 passed
- PowerShell read-only smoke script syntax verified
- wheel built with `uv build --wheel` and verified to include Research API/CLI modules plus Web templates/static assets
- controlled live execution of `1 + 1` returned `2`; kernel/session counts were zero before and after cleanup
